### PR TITLE
Basic JEI integration

### DIFF
--- a/src/api/java/com/ldtteam/domumornamentum/block/IMateriallyTexturedBlock.java
+++ b/src/api/java/com/ldtteam/domumornamentum/block/IMateriallyTexturedBlock.java
@@ -1,7 +1,9 @@
 package com.ldtteam.domumornamentum.block;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
+import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.ldtteam.domumornamentum.recipe.ModRecipeSerializers;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.resources.ResourceLocation;
@@ -11,7 +13,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
 
 public interface IMateriallyTexturedBlock
 {
@@ -57,5 +62,20 @@ public interface IMateriallyTexturedBlock
               }
           }
         );
+    }
+
+    @NotNull
+    default MaterialTextureData getRandomMaterials()
+    {
+        final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+        for (final IMateriallyTexturedBlockComponent component : getComponents())
+        {
+            final List<Block> candidates = component.getValidSkins().getValues();
+            if (candidates.isEmpty()) continue;
+
+            final Block texture = candidates.get(ThreadLocalRandom.current().nextInt(candidates.size()));
+            textureData.put(component.getId(), texture);
+        }
+        return new MaterialTextureData(textureData);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/ModBlocks.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/ModBlocks.java
@@ -4,16 +4,14 @@ import com.google.common.collect.Lists;
 import com.ldtteam.domumornamentum.block.decorative.*;
 import com.ldtteam.domumornamentum.block.types.BrickType;
 import com.ldtteam.domumornamentum.block.types.ExtraBlockType;
-import com.ldtteam.domumornamentum.block.types.FancyTrapdoorType;
 import com.ldtteam.domumornamentum.block.types.TimberFrameType;
 import com.ldtteam.domumornamentum.block.vanilla.*;
-import com.ldtteam.domumornamentum.block.vanilla.SlabBlock;
 import com.ldtteam.domumornamentum.util.Constants;
 import net.minecraft.world.item.DyeColor;
-import net.minecraft.world.level.block.state.BlockBehaviour;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.material.Material;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.material.Material;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -225,16 +223,16 @@ public final class ModBlocks implements IModBlocks
         final IForgeRegistry<Item> registry = event.getRegistry();
         ARCHITECTS_CUTTER.registerItemBlock(registry, (new Item.Properties().tab(ModCreativeTabs.GENERAL)));
 
-        final Item.Properties timberframeProperties = new Item.Properties();
+        final Item.Properties timberframeProperties = new Item.Properties().tab(ModCreativeTabs.GENERAL);
 
         for (final TimberFrameBlock frame : TIMBER_FRAMES)
         {
             frame.registerItemBlock(registry, timberframeProperties);
         }
 
-        SHINGLE.registerItemBlock(registry, new Item.Properties());
-        SHINGLE_SLAB.registerItemBlock(registry, new Item.Properties());
-        PAPER_WALL.registerItemBlock(registry, new Item.Properties());
+        SHINGLE.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.GENERAL));
+        SHINGLE_SLAB.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.GENERAL));
+        PAPER_WALL.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.GENERAL));
 
         for (final ExtraBlock block : EXTRA_TOP_BLOCKS)
         {
@@ -254,15 +252,15 @@ public final class ModBlocks implements IModBlocks
         STANDING_BARREL.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.EXTRA_BLOCKS));
         LAYING_BARREL.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.EXTRA_BLOCKS));
 
-        FENCE.registerItemBlock(registry, new Item.Properties());
-        FENCE_GATE.registerItemBlock(registry, new Item.Properties());
-        SLAB.registerItemBlock(registry, new Item.Properties());
-        WALL.registerItemBlock(registry, new Item.Properties());
-        STAIR.registerItemBlock(registry, new Item.Properties());
-        TRAPDOOR.registerItemBlock(registry, new Item.Properties());
-        DOOR.registerItemBlock(registry, new Item.Properties());
+        FENCE.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.GENERAL));
+        FENCE_GATE.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.GENERAL));
+        SLAB.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.GENERAL));
+        WALL.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.GENERAL));
+        STAIR.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.GENERAL));
+        TRAPDOOR.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.GENERAL));
+        DOOR.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.GENERAL));
 
-        FANCY_DOOR.registerItemBlock(registry, new Item.Properties());
-        FANCY_TRAPDOOR.registerItemBlock(registry, new Item.Properties());
+        FANCY_DOOR.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.GENERAL));
+        FANCY_TRAPDOOR.registerItemBlock(registry, new Item.Properties().tab(ModCreativeTabs.GENERAL));
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
@@ -2,20 +2,17 @@ package com.ldtteam.domumornamentum.block.decorative;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
 import com.ldtteam.domumornamentum.block.AbstractBlockDoor;
 import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
 import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
 import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
 import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
-import com.ldtteam.domumornamentum.block.types.DoorType;
 import com.ldtteam.domumornamentum.block.types.FancyDoorType;
 import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
 import com.ldtteam.domumornamentum.entity.block.ModBlockEntityTypes;
 import com.ldtteam.domumornamentum.item.decoration.FancyDoorBlockItem;
-import com.ldtteam.domumornamentum.item.vanilla.DoorBlockItem;
 import com.ldtteam.domumornamentum.recipe.ModRecipeSerializers;
 import com.ldtteam.domumornamentum.tag.ModTags;
 import com.ldtteam.domumornamentum.util.BlockUtils;
@@ -24,7 +21,6 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.Tag;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -106,50 +102,18 @@ public class FancyDoorBlock extends AbstractBlockDoor<FancyDoorBlock> implements
             return;
         }
 
-        IMateriallyTexturedBlockComponent innerComponent = getComponents().get(0);
-        IMateriallyTexturedBlockComponent outerComponent = getComponents().get(1);
-
-        final Tag<Block> innerCandidate = innerComponent.getValidSkins();
-        final Tag<Block> outerCandidate = innerComponent.getValidSkins();
-
-
         try {
             for (final FancyDoorType fancyDoorType : FancyDoorType.values())
             {
-                innerCandidate.getValues().forEach(cover -> {
-                    final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+                final MaterialTextureData materialTextureData = getRandomMaterials();
+                final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                    textureData.put(innerComponent.getId(), cover);
+                final ItemStack result = new ItemStack(this);
+                result.getOrCreateTag().put("textureData", textureNbt);
+                result.getOrCreateTag().putString("type", fancyDoorType.toString().toUpperCase());
 
-                    final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                    final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                    final ItemStack result = new ItemStack(this);
-                    result.getOrCreateTag().put("textureData", textureNbt);
-                    result.getOrCreateTag().putString("type", fancyDoorType.toString().toUpperCase());
-
-                    fillItemGroupCache.add(result);
-
-                    outerCandidate.getValues().forEach(outer -> {
-                        final Map<ResourceLocation, Block> combinedTextureData = Maps.newHashMap(textureData);
-
-                        combinedTextureData.put(outerComponent.getId(), outer);
-
-                        final MaterialTextureData combinedMaterialTextureData = new MaterialTextureData(combinedTextureData);
-
-                        final CompoundTag combinedTextureNbt = combinedMaterialTextureData.serializeNBT();
-
-                        final ItemStack combinedResult = new ItemStack(this);
-                        combinedResult.getOrCreateTag().put("textureData", combinedTextureNbt);
-                        combinedResult.getOrCreateTag().putString("type", fancyDoorType.toString().toUpperCase());
-
-                        fillItemGroupCache.add(combinedResult);
-                    });
-                });
+                fillItemGroupCache.add(result);
             }
-
-
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
@@ -2,7 +2,6 @@ package com.ldtteam.domumornamentum.block.decorative;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
 import com.ldtteam.domumornamentum.block.AbstractBlockTrapdoor;
 import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
@@ -10,12 +9,10 @@ import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
 import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
 import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
 import com.ldtteam.domumornamentum.block.types.FancyTrapdoorType;
-import com.ldtteam.domumornamentum.block.types.TrapdoorType;
 import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
 import com.ldtteam.domumornamentum.entity.block.ModBlockEntityTypes;
 import com.ldtteam.domumornamentum.item.decoration.FancyTrapdoorBlockItem;
-import com.ldtteam.domumornamentum.item.vanilla.TrapdoorBlockItem;
 import com.ldtteam.domumornamentum.recipe.ModRecipeSerializers;
 import com.ldtteam.domumornamentum.tag.ModTags;
 import com.ldtteam.domumornamentum.util.BlockUtils;
@@ -24,7 +21,6 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.Tag;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -49,7 +45,10 @@ import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 
 import static net.minecraft.world.level.block.Blocks.ACACIA_PLANKS;
 import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
@@ -99,48 +98,18 @@ public class FancyTrapdoorBlock extends AbstractBlockTrapdoor<FancyTrapdoorBlock
             return;
         }
 
-        IMateriallyTexturedBlockComponent innerComponent = getComponents().get(0);
-        IMateriallyTexturedBlockComponent outerComponent = getComponents().get(1);
-
-        final Tag<Block> innerCandidate = innerComponent.getValidSkins();
-        final Tag<Block> outerCandidate = innerComponent.getValidSkins();
-
         try {
             for (final FancyTrapdoorType trapdoorType : FancyTrapdoorType.values())
             {
-                innerCandidate.getValues().forEach(cover -> {
-                    final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+                final MaterialTextureData materialTextureData = getRandomMaterials();
+                final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                    textureData.put(innerComponent.getId(), cover);
+                final ItemStack result = new ItemStack(this);
+                result.getOrCreateTag().put("textureData", textureNbt);
+                result.getOrCreateTag().putString("type", trapdoorType.toString().toUpperCase());
 
-                    final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                    final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                    final ItemStack result = new ItemStack(this);
-                    result.getOrCreateTag().put("textureData", textureNbt);
-                    result.getOrCreateTag().putString("type", trapdoorType.toString().toUpperCase());
-
-                    fillItemGroupCache.add(result);
-                    outerCandidate.getValues().forEach(outer -> {
-                        final Map<ResourceLocation, Block> combinedTextureData = Maps.newHashMap(textureData);
-
-                        combinedTextureData.put(outerComponent.getId(), outer);
-
-                        final MaterialTextureData combinedMaterialTextureData = new MaterialTextureData(combinedTextureData);
-
-                        final CompoundTag combinedTextureNbt = combinedMaterialTextureData.serializeNBT();
-
-                        final ItemStack combinedResult = new ItemStack(this);
-                        combinedResult.getOrCreateTag().put("textureData", combinedTextureNbt);
-                        combinedResult.getOrCreateTag().putString("type", trapdoorType.toString().toUpperCase());
-
-                        fillItemGroupCache.add(combinedResult);
-                    });
-                });
+                fillItemGroupCache.add(result);
             }
-
-
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PaperWallBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PaperWallBlock.java
@@ -2,7 +2,6 @@ package com.ldtteam.domumornamentum.block.decorative;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
 import com.ldtteam.domumornamentum.block.AbstractBlockPane;
 import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
@@ -21,7 +20,6 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.Tag;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -40,7 +38,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
@@ -48,7 +45,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -133,30 +129,14 @@ public class PaperWallBlock extends AbstractBlockPane<PaperWallBlock> implements
             return;
         }
 
-        IMateriallyTexturedBlockComponent frameComponent = getComponents().get(0);
-        IMateriallyTexturedBlockComponent centerComponent = getComponents().get(1);
-
-        final Tag<Block> frameCandidates = frameComponent.getValidSkins();
-        final Tag<Block> centerCandidates = centerComponent.getValidSkins();
-
         try {
-            frameCandidates.getValues().forEach(cover -> {
-                centerCandidates.getValues().forEach(support ->{
-                    final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+            final MaterialTextureData materialTextureData = getRandomMaterials();
+            final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                    textureData.put(frameComponent.getId(), cover);
-                    textureData.put(centerComponent.getId(), support);
+            final ItemStack result = new ItemStack(this);
+            result.getOrCreateTag().put("textureData", textureNbt);
 
-                    final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                    final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                    final ItemStack result = new ItemStack(this);
-                    result.getOrCreateTag().put("textureData", textureNbt);
-
-                    fillItemGroupCache.add(result);
-                });
-            });
+            fillItemGroupCache.add(result);
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleBlock.java
@@ -1,13 +1,7 @@
 package com.ldtteam.domumornamentum.block.decorative;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
 import com.ldtteam.domumornamentum.block.AbstractBlockStairs;
 import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
@@ -23,33 +17,35 @@ import com.ldtteam.domumornamentum.recipe.ModRecipeSerializers;
 import com.ldtteam.domumornamentum.tag.ModTags;
 import com.ldtteam.domumornamentum.util.BlockUtils;
 import com.ldtteam.domumornamentum.util.Constants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.material.Material;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.block.state.properties.StairsShape;
-import net.minecraft.tags.Tag;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.core.NonNullList;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.StairsShape;
+import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Class defining the general shingle.
@@ -120,30 +116,14 @@ public class ShingleBlock extends AbstractBlockStairs<ShingleBlock> implements I
             return;
         }
 
-        IMateriallyTexturedBlockComponent coverComponent = getComponents().get(0);
-        IMateriallyTexturedBlockComponent supportComponent = getComponents().get(1);
-
-        final Tag<Block> coverCandidates = coverComponent.getValidSkins();
-        final Tag<Block> supportCandidates = supportComponent.getValidSkins();
-
         try {
-            coverCandidates.getValues().forEach(cover -> {
-                supportCandidates.getValues().forEach(support ->{
-                    final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+            final MaterialTextureData materialTextureData = getRandomMaterials();
+            final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                    textureData.put(coverComponent.getId(), cover);
-                    textureData.put(supportComponent.getId(), support);
+            final ItemStack result = new ItemStack(this);
+            result.getOrCreateTag().put("textureData", textureNbt);
 
-                    final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                    final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                    final ItemStack result = new ItemStack(this);
-                    result.getOrCreateTag().put("textureData", textureNbt);
-
-                    fillItemGroupCache.add(result);
-                });
-            });
+            fillItemGroupCache.add(result);
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleSlabBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleSlabBlock.java
@@ -2,7 +2,6 @@ package com.ldtteam.domumornamentum.block.decorative;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
 import com.ldtteam.domumornamentum.block.AbstractBlockDirectional;
 import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
@@ -18,50 +17,47 @@ import com.ldtteam.domumornamentum.recipe.ModRecipeSerializers;
 import com.ldtteam.domumornamentum.tag.ModTags;
 import com.ldtteam.domumornamentum.util.BlockUtils;
 import com.ldtteam.domumornamentum.util.Constants;
-import net.minecraft.data.recipes.FinishedRecipe;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.crafting.RecipeSerializer;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.SimpleWaterloggedBlock;
-import net.minecraft.world.level.material.Material;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.level.material.FluidState;
-import net.minecraft.world.level.material.Fluids;
-import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.pathfinder.PathComputationType;
-import net.minecraft.world.level.block.state.properties.BooleanProperty;
-import net.minecraft.world.level.block.state.properties.EnumProperty;
-import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.tags.FluidTags;
-import net.minecraft.tags.Tag;
-import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
+import net.minecraft.data.recipes.FinishedRecipe;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.core.BlockPos;
+import net.minecraft.tags.FluidTags;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.SimpleWaterloggedBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
+import net.minecraft.world.level.material.Material;
+import net.minecraft.world.level.pathfinder.PathComputationType;
 import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.Level;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static com.ldtteam.domumornamentum.block.types.ShingleSlabShapeType.*;
@@ -310,35 +306,14 @@ public class ShingleSlabBlock extends AbstractBlockDirectional<ShingleSlabBlock>
             return;
         }
 
-        IMateriallyTexturedBlockComponent roofComponent = getComponents().get(0);
-        IMateriallyTexturedBlockComponent supportComponent = getComponents().get(1);
-        IMateriallyTexturedBlockComponent coverComponent = getComponents().get(2);
-
-        final Tag<Block> roofCandidates = roofComponent.getValidSkins();
-        final Tag<Block> supportCandidates = supportComponent.getValidSkins();
-        final Tag<Block> coverCandidates = coverComponent.getValidSkins();
-
         try {
-            roofCandidates.getValues().forEach(roof -> {
-                supportCandidates.getValues().forEach(support ->{
-                    coverCandidates.getValues().forEach(cover -> {
-                        final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+            final MaterialTextureData materialTextureData = getRandomMaterials();
+            final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                        textureData.put(roofComponent.getId(), roof);
-                        textureData.put(supportComponent.getId(), support);
-                        textureData.put(coverComponent.getId(), cover);
+            final ItemStack result = new ItemStack(this);
+            result.getOrCreateTag().put("textureData", textureNbt);
 
-                        final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                        final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                        final ItemStack result = new ItemStack(this);
-                        result.getOrCreateTag().put("textureData", textureNbt);
-
-                        fillItemGroupCache.add(result);
-                    });
-                });
-            });
+            fillItemGroupCache.add(result);
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/TimberFrameBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/TimberFrameBlock.java
@@ -2,7 +2,6 @@ package com.ldtteam.domumornamentum.block.decorative;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
 import com.ldtteam.domumornamentum.block.AbstractBlock;
 import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
@@ -11,33 +10,35 @@ import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
 import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
 import com.ldtteam.domumornamentum.block.types.TimberFrameType;
 import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
-import com.ldtteam.domumornamentum.entity.block.ModBlockEntityTypes;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
+import com.ldtteam.domumornamentum.entity.block.ModBlockEntityTypes;
 import com.ldtteam.domumornamentum.item.decoration.TimberFrameBlockItem;
 import com.ldtteam.domumornamentum.recipe.ModRecipeSerializers;
 import com.ldtteam.domumornamentum.tag.ModTags;
 import com.ldtteam.domumornamentum.util.BlockUtils;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.material.Material;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.tags.Tag;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.core.NonNullList;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.properties.DirectionProperty;
+import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.PushReaction;
 import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
@@ -45,13 +46,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-
-import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.BlockPlaceContext;
 
 /**
  * Decorative block
@@ -150,30 +145,14 @@ public class TimberFrameBlock extends AbstractBlock<TimberFrameBlock> implements
             return;
         }
 
-        IMateriallyTexturedBlockComponent outerComponent = getComponents().get(0);
-        IMateriallyTexturedBlockComponent innerComponent = getComponents().get(1);
-
-        final Tag<Block> outerCandidates = outerComponent.getValidSkins();
-        final Tag<Block> innerCandidates = innerComponent.getValidSkins();
-
         try {
-            outerCandidates.getValues().forEach(outer -> {
-                innerCandidates.getValues().forEach(inner ->{
-                    final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+            final MaterialTextureData materialTextureData = getRandomMaterials();
+            final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                    textureData.put(outerComponent.getId(), outer);
-                    textureData.put(innerComponent.getId(), inner);
+            final ItemStack result = new ItemStack(this);
+            result.getOrCreateTag().put("textureData", textureNbt);
 
-                    final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                    final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                    final ItemStack result = new ItemStack(this);
-                    result.getOrCreateTag().put("textureData", textureNbt);
-
-                    fillItemGroupCache.add(result);
-                });
-            });
+            fillItemGroupCache.add(result);
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
@@ -2,7 +2,6 @@ package com.ldtteam.domumornamentum.block.vanilla;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
 import com.ldtteam.domumornamentum.block.AbstractBlockDoor;
 import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
@@ -10,7 +9,6 @@ import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
 import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
 import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
 import com.ldtteam.domumornamentum.block.types.DoorType;
-import com.ldtteam.domumornamentum.block.types.FancyDoorType;
 import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
 import com.ldtteam.domumornamentum.entity.block.ModBlockEntityTypes;
@@ -23,7 +21,6 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.Tag;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -97,31 +94,18 @@ public class DoorBlock extends AbstractBlockDoor<DoorBlock> implements IMaterial
             return;
         }
 
-        IMateriallyTexturedBlockComponent materialComponent = getComponents().get(0);
-
-        final Tag<Block> materialCandidate = materialComponent.getValidSkins();
-
         try {
             for (final DoorType DoorType : DoorType.values())
             {
-                materialCandidate.getValues().forEach(cover -> {
-                    final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+                final MaterialTextureData materialTextureData = getRandomMaterials();
+                final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                    textureData.put(materialComponent.getId(), cover);
+                final ItemStack result = new ItemStack(this);
+                result.getOrCreateTag().put("textureData", textureNbt);
+                result.getOrCreateTag().putString("type", DoorType.toString().toUpperCase());
 
-                    final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                    final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                    final ItemStack result = new ItemStack(this);
-                    result.getOrCreateTag().put("textureData", textureNbt);
-                    result.getOrCreateTag().putString("type", DoorType.toString().toUpperCase());
-
-                    fillItemGroupCache.add(result);
-                });
+                fillItemGroupCache.add(result);
             }
-
-
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceBlock.java
@@ -2,7 +2,6 @@ package com.ldtteam.domumornamentum.block.vanilla;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.ldtteam.domumornamentum.block.AbstractBlockFence;
 import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
 import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
@@ -19,7 +18,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.Tag;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -35,14 +33,12 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
@@ -81,25 +77,14 @@ public class FenceBlock extends AbstractBlockFence<FenceBlock> implements IMater
             return;
         }
 
-        IMateriallyTexturedBlockComponent materialComponent = getComponents().get(0);
-
-        final Tag<Block> materialCandidate = materialComponent.getValidSkins();
-
         try {
-            materialCandidate.getValues().forEach(cover -> {
-                final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+            final MaterialTextureData materialTextureData = getRandomMaterials();
+            final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                textureData.put(materialComponent.getId(), cover);
+            final ItemStack result = new ItemStack(this);
+            result.getOrCreateTag().put("textureData", textureNbt);
 
-                final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                final ItemStack result = new ItemStack(this);
-                result.getOrCreateTag().put("textureData", textureNbt);
-
-                fillItemGroupCache.add(result);
-            });
+            fillItemGroupCache.add(result);
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceGateBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceGateBlock.java
@@ -2,13 +2,14 @@ package com.ldtteam.domumornamentum.block.vanilla;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.ldtteam.domumornamentum.block.*;
+import com.ldtteam.domumornamentum.block.AbstractBlockFenceGate;
+import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
 import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
 import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
 import com.ldtteam.domumornamentum.entity.block.ModBlockEntityTypes;
-import com.ldtteam.domumornamentum.item.vanilla.FenceBlockItem;
 import com.ldtteam.domumornamentum.item.vanilla.FenceGateBlockItem;
 import com.ldtteam.domumornamentum.tag.ModTags;
 import com.ldtteam.domumornamentum.util.BlockUtils;
@@ -17,7 +18,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.Tag;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -32,14 +32,12 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
@@ -78,25 +76,14 @@ public class FenceGateBlock extends AbstractBlockFenceGate<FenceGateBlock> imple
             return;
         }
 
-        IMateriallyTexturedBlockComponent materialComponent = getComponents().get(0);
-
-        final Tag<Block> materialCandidate = materialComponent.getValidSkins();
-
         try {
-            materialCandidate.getValues().forEach(cover -> {
-                final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+            final MaterialTextureData materialTextureData = getRandomMaterials();
+            final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                textureData.put(materialComponent.getId(), cover);
+            final ItemStack result = new ItemStack(this);
+            result.getOrCreateTag().put("textureData", textureNbt);
 
-                final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                final ItemStack result = new ItemStack(this);
-                result.getOrCreateTag().put("textureData", textureNbt);
-
-                fillItemGroupCache.add(result);
-            });
+            fillItemGroupCache.add(result);
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/SlabBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/SlabBlock.java
@@ -2,9 +2,11 @@ package com.ldtteam.domumornamentum.block.vanilla;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
-import com.ldtteam.domumornamentum.block.*;
+import com.ldtteam.domumornamentum.block.AbstractBlockSlab;
+import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
 import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
 import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
@@ -19,7 +21,6 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.Tag;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -36,7 +37,6 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
@@ -44,7 +44,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
@@ -83,25 +82,14 @@ public class SlabBlock extends AbstractBlockSlab<SlabBlock> implements IMaterial
             return;
         }
 
-        IMateriallyTexturedBlockComponent materialComponent = getComponents().get(0);
-
-        final Tag<Block> materialCandidate = materialComponent.getValidSkins();
-
         try {
-            materialCandidate.getValues().forEach(cover -> {
-                final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+            final MaterialTextureData materialTextureData = getRandomMaterials();
+            final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                textureData.put(materialComponent.getId(), cover);
+            final ItemStack result = new ItemStack(this);
+            result.getOrCreateTag().put("textureData", textureNbt);
 
-                final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                final ItemStack result = new ItemStack(this);
-                result.getOrCreateTag().put("textureData", textureNbt);
-
-                fillItemGroupCache.add(result);
-            });
+            fillItemGroupCache.add(result);
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/StairBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/StairBlock.java
@@ -2,7 +2,6 @@ package com.ldtteam.domumornamentum.block.vanilla;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.ldtteam.domumornamentum.block.AbstractBlockStairs;
 import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
 import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
@@ -20,7 +19,6 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.tags.Tag;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
@@ -41,7 +39,6 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.registries.IForgeRegistry;
@@ -49,7 +46,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 
@@ -90,25 +86,14 @@ public class StairBlock extends AbstractBlockStairs<StairBlock> implements IMate
             return;
         }
 
-        IMateriallyTexturedBlockComponent materialComponent = getComponents().get(0);
-
-        final Tag<Block> materialCandidate = materialComponent.getValidSkins();
-
         try {
-            materialCandidate.getValues().forEach(cover -> {
-                final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+            final MaterialTextureData materialTextureData = getRandomMaterials();
+            final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                textureData.put(materialComponent.getId(), cover);
+            final ItemStack result = new ItemStack(this);
+            result.getOrCreateTag().put("textureData", textureNbt);
 
-                final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                final ItemStack result = new ItemStack(this);
-                result.getOrCreateTag().put("textureData", textureNbt);
-
-                fillItemGroupCache.add(result);
-            });
+            fillItemGroupCache.add(result);
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
@@ -2,14 +2,12 @@ package com.ldtteam.domumornamentum.block.vanilla;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
 import com.ldtteam.domumornamentum.block.AbstractBlockTrapdoor;
 import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
 import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
 import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
 import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
-import com.ldtteam.domumornamentum.block.types.FancyDoorType;
 import com.ldtteam.domumornamentum.block.types.TrapdoorType;
 import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
@@ -23,7 +21,6 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.Tag;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -42,14 +39,16 @@ import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.material.MaterialColor;
 import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 
 import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
 
@@ -97,31 +96,18 @@ public class TrapdoorBlock extends AbstractBlockTrapdoor<TrapdoorBlock> implemen
             return;
         }
 
-        IMateriallyTexturedBlockComponent materialComponent = getComponents().get(0);
-
-        final Tag<Block> materialCandidate = materialComponent.getValidSkins();
-
         try {
             for (final TrapdoorType trapdoorType : TrapdoorType.values())
             {
-                materialCandidate.getValues().forEach(cover -> {
-                    final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+                final MaterialTextureData materialTextureData = getRandomMaterials();
+                final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                    textureData.put(materialComponent.getId(), cover);
+                final ItemStack result = new ItemStack(this);
+                result.getOrCreateTag().put("textureData", textureNbt);
+                result.getOrCreateTag().putString("type", trapdoorType.toString().toUpperCase());
 
-                    final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                    final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                    final ItemStack result = new ItemStack(this);
-                    result.getOrCreateTag().put("textureData", textureNbt);
-                    result.getOrCreateTag().putString("type", trapdoorType.toString().toUpperCase());
-
-                    fillItemGroupCache.add(result);
-                });
+                fillItemGroupCache.add(result);
             }
-
-
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/WallBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/WallBlock.java
@@ -2,13 +2,14 @@ package com.ldtteam.domumornamentum.block.vanilla;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.ldtteam.domumornamentum.block.*;
+import com.ldtteam.domumornamentum.block.AbstractBlockWall;
+import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
 import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
 import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
 import com.ldtteam.domumornamentum.entity.block.ModBlockEntityTypes;
-import com.ldtteam.domumornamentum.item.vanilla.FenceBlockItem;
 import com.ldtteam.domumornamentum.item.vanilla.WallBlockItem;
 import com.ldtteam.domumornamentum.tag.ModTags;
 import com.ldtteam.domumornamentum.util.BlockUtils;
@@ -17,7 +18,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.Tag;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -32,14 +32,12 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.registries.IForgeRegistry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
@@ -78,25 +76,14 @@ public class WallBlock extends AbstractBlockWall<WallBlock> implements IMaterial
             return;
         }
 
-        IMateriallyTexturedBlockComponent materialComponent = getComponents().get(0);
-
-        final Tag<Block> materialCandidate = materialComponent.getValidSkins();
-
         try {
-            materialCandidate.getValues().forEach(cover -> {
-                final Map<ResourceLocation, Block> textureData = Maps.newHashMap();
+            final MaterialTextureData materialTextureData = getRandomMaterials();
+            final CompoundTag textureNbt = materialTextureData.serializeNBT();
 
-                textureData.put(materialComponent.getId(), cover);
+            final ItemStack result = new ItemStack(this);
+            result.getOrCreateTag().put("textureData", textureNbt);
 
-                final MaterialTextureData materialTextureData = new MaterialTextureData(textureData);
-
-                final CompoundTag textureNbt = materialTextureData.serializeNBT();
-
-                final ItemStack result = new ItemStack(this);
-                result.getOrCreateTag().put("textureData", textureNbt);
-
-                fillItemGroupCache.add(result);
-            });
+            fillItemGroupCache.add(result);
         } catch (IllegalStateException exception)
         {
             //Ignored. Thrown during start up.

--- a/src/main/java/com/ldtteam/domumornamentum/event/handlers/ForgeBusEventHandler.java
+++ b/src/main/java/com/ldtteam/domumornamentum/event/handlers/ForgeBusEventHandler.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 public class ForgeBusEventHandler
 {
 
-    private static final boolean ACTIVE = true;
+    private static final boolean ACTIVE = false;
     private static final Logger LOGGER = LogManager.getLogger();
 
     @SubscribeEvent

--- a/src/main/java/com/ldtteam/domumornamentum/jei/ArchitectsCutterCategory.java
+++ b/src/main/java/com/ldtteam/domumornamentum/jei/ArchitectsCutterCategory.java
@@ -1,0 +1,271 @@
+package com.ldtteam.domumornamentum.jei;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.ldtteam.domumornamentum.IDomumOrnamentumApi;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockManager;
+import com.ldtteam.domumornamentum.recipe.ModRecipeSerializers;
+import com.ldtteam.domumornamentum.recipe.architectscutter.ArchitectsCutterRecipe;
+import com.mojang.blaze3d.vertex.PoseStack;
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.ingredient.IGuiIngredient;
+import mezz.jei.api.gui.ingredient.IGuiItemStackGroup;
+import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.Container;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.ldtteam.domumornamentum.util.Constants.MOD_ID;
+
+@OnlyIn(Dist.CLIENT)
+public class ArchitectsCutterCategory implements IRecipeCategory<ArchitectsCutterRecipe>
+{
+    private final JEIPlugin plugin;
+    private final IDrawable background;
+    private final IDrawable thumb;
+    private final IDrawable slot;
+    private final IDrawable button;
+    private final IDrawable icon;
+    private final LoadingCache<ArchitectsCutterRecipe, DisplayData> cachedDisplayData;
+
+    public ArchitectsCutterCategory(@NotNull final IGuiHelper guiHelper, @NotNull final JEIPlugin plugin)
+    {
+        this.plugin = plugin;
+        final ResourceLocation texture = new ResourceLocation(MOD_ID, "textures/gui/container/architectscutter.png");
+        this.background = guiHelper.createDrawable(texture, 3, 12, 170, 60);
+        this.thumb = guiHelper.createDrawable(texture, 176, 0, 12, 15);
+        this.slot = guiHelper.createDrawable(texture, 16, 166, 18, 18);
+        this.button = guiHelper.createDrawable(texture, 0, 166, 16, 18);
+        this.icon = guiHelper.createDrawableIngredient(new ItemStack(IDomumOrnamentumApi.getInstance().getBlocks().getArchitectsCutter()));
+        this.cachedDisplayData = CacheBuilder.newBuilder()
+                .maximumSize(25)
+                .build(new CacheLoader<>()
+                {
+                    @Override
+                    public DisplayData load(@NotNull final ArchitectsCutterRecipe key)
+                    {
+                        return new DisplayData(key);
+                    }
+                });
+    }
+
+    @NotNull
+    @Override
+    public ResourceLocation getUid()
+    {
+        return Objects.requireNonNull(ModRecipeSerializers.ARCHITECTS_CUTTER.getRegistryName());
+    }
+
+    @NotNull
+    @Override
+    public Class<? extends ArchitectsCutterRecipe> getRecipeClass()
+    {
+        return ArchitectsCutterRecipe.class;
+    }
+
+    @NotNull
+    @Override
+    public Component getTitle()
+    {
+        return new TranslatableComponent(MOD_ID + ".architectscutter");
+    }
+
+    @NotNull
+    @Override
+    public IDrawable getBackground()
+    {
+        return this.background;
+    }
+
+    @NotNull
+    @Override
+    public IDrawable getIcon()
+    {
+        return this.icon;
+    }
+
+    @Override
+    public void setIngredients(@NotNull final ArchitectsCutterRecipe recipe,
+                               @NotNull final IIngredients ingredients)
+    {
+        final Block generatedBlock = ForgeRegistries.BLOCKS.getValue(recipe.getBlockName());
+
+        if (!(generatedBlock instanceof final IMateriallyTexturedBlock materiallyTexturedBlock))
+            return;
+
+        final Collection<IMateriallyTexturedBlockComponent> components = materiallyTexturedBlock.getComponents();
+        final List<List<ItemStack>> inputs = components.stream()
+                .map(component -> component.getValidSkins().getValues().stream()
+                        .map(ItemStack::new)
+                        .collect(Collectors.toList()))
+                .collect(Collectors.toList());
+        ingredients.setInputLists(VanillaTypes.ITEM, inputs);
+
+        final List<ItemStack> defaultInputs = components.stream()
+                .map(component -> new ItemStack(component.getDefault()))
+                .collect(Collectors.toList());
+
+        final DisplayData displayData = cachedDisplayData.getUnchecked(recipe);
+        final Container container = displayData.getIngredientContainer();
+
+        for (int i = 0; i < defaultInputs.size(); ++i)
+        {
+            container.setItem(i, defaultInputs.get(i));
+        }
+
+        // for the sake of not polluting JEI too much we'll only show one example output block
+        ItemStack output = recipe.assemble(container);
+        if (output.isEmpty())   // wat?
+        {
+            output = recipe.getResultItem();
+            if (output.isEmpty())   // WAT?
+            {
+                output = new ItemStack(generatedBlock);
+            }
+            output.setCount(Math.max(components.size(), recipe.getCount()));
+        }
+
+        displayData.setOutput(output);
+        ingredients.setOutput(VanillaTypes.ITEM, output);
+    }
+
+    @Override
+    public void setRecipe(@NotNull final IRecipeLayout recipeLayout,
+                          @NotNull final ArchitectsCutterRecipe recipe,
+                          @NotNull final IIngredients ingredients)
+    {
+        final IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+
+        itemStacks.init(0, false, 139, 20);
+
+        for (int slot = 0; slot < IMateriallyTexturedBlockManager.getInstance().getMaxTexturableComponentCount(); ++slot)
+        {
+            final int x = 5 + ((slot & 1) * 20);
+            final int y = 2 + ((slot >> 1) * 20);
+            itemStacks.init(1 + slot, true, x, y);
+            itemStacks.setBackground(1 + slot, this.slot);
+        }
+
+        itemStacks.set(ingredients);
+
+        final DisplayData displayData = cachedDisplayData.getUnchecked(recipe);
+        displayData.setItemStacks(itemStacks);
+    }
+
+    @Override
+    public void draw(@NotNull final ArchitectsCutterRecipe recipe,
+                     @NotNull final PoseStack stack,
+                     final double mouseX, final double mouseY)
+    {
+        final DisplayData displayData = cachedDisplayData.getUnchecked(recipe);
+
+        this.thumb.draw(stack, 116, 3);
+
+        this.button.draw(stack, 74, 21);
+        this.plugin.getIngredientManager().getIngredientRenderer(VanillaTypes.ITEM)
+            .render(stack, 74, 22, recipe.getResultItem());
+
+        displayData.reassembleIfNeeded();
+        Objects.requireNonNull(displayData.getItemStacks()).set(0, List.of(displayData.getOutput()));
+    }
+
+    private static class DisplayData
+    {
+        private final ArchitectsCutterRecipe recipe;
+
+        @Nullable
+        private IGuiItemStackGroup itemStacks;
+
+        private ItemStack output = ItemStack.EMPTY;
+
+        private final Container ingredientContainer =
+                new SimpleContainer(IMateriallyTexturedBlockManager.getInstance().getMaxTexturableComponentCount());
+
+        public DisplayData(@NotNull final ArchitectsCutterRecipe recipe)
+        {
+            this.recipe = recipe;
+        }
+
+        @Nullable
+        public IGuiItemStackGroup getItemStacks()
+        {
+            return this.itemStacks;
+        }
+        public void setItemStacks(@NotNull final IGuiItemStackGroup itemStacks)
+        {
+            this.itemStacks = itemStacks;
+        }
+
+        @NotNull
+        public Container getIngredientContainer()
+        {
+            return this.ingredientContainer;
+        }
+
+        @NotNull
+        public ItemStack getOutput()
+        {
+            return this.output;
+        }
+
+        public void setOutput(@NotNull final ItemStack output)
+        {
+            this.output = output;
+        }
+
+        public void reassembleIfNeeded()
+        {
+            final Map<Integer, ? extends IGuiIngredient<ItemStack>> ingredients = this.itemStacks.getGuiIngredients();
+
+            final List<ItemStack> inputs = new ArrayList<>(ingredients.size());
+            for (int i = 0; i < ingredients.size(); ++i)
+            {
+                final IGuiIngredient<ItemStack> ingredient = ingredients.get(i);
+                if (!ingredient.isInput()) continue;
+
+                inputs.add(Objects.requireNonNullElse(ingredient.getDisplayedIngredient(), ItemStack.EMPTY));
+            }
+
+            if (!containerMatches(inputs))
+            {
+                for (int i = 0; i < inputs.size(); ++i)
+                {
+                    this.ingredientContainer.setItem(i, inputs.get(i));
+                }
+
+                this.output = recipe.assemble(this.ingredientContainer);
+            }
+        }
+
+        private boolean containerMatches(@NotNull final List<ItemStack> inputs)
+        {
+            for (int i = 0; i < this.ingredientContainer.getContainerSize(); ++i)
+            {
+                if (!ItemStack.isSameItemSameTags(i < inputs.size() ? inputs.get(i) : ItemStack.EMPTY, this.ingredientContainer.getItem(i)))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/ldtteam/domumornamentum/jei/ArchitectsCutterCategory.java
+++ b/src/main/java/com/ldtteam/domumornamentum/jei/ArchitectsCutterCategory.java
@@ -116,7 +116,13 @@ public class ArchitectsCutterCategory implements IRecipeCategory<ArchitectsCutte
         final List<List<ItemStack>> inputs = components.stream()
                 .map(component -> component.getValidSkins().getValues().stream()
                         .map(ItemStack::new)
-                        .collect(Collectors.toList()))
+                        .collect(Collectors.collectingAndThen(
+                                Collectors.toCollection(ArrayList::new),
+                                list ->
+                                {
+                                    Collections.shuffle(list);
+                                    return list;
+                                })))
                 .collect(Collectors.toList());
         ingredients.setInputLists(VanillaTypes.ITEM, inputs);
 

--- a/src/main/java/com/ldtteam/domumornamentum/jei/JEIPlugin.java
+++ b/src/main/java/com/ldtteam/domumornamentum/jei/JEIPlugin.java
@@ -1,0 +1,79 @@
+package com.ldtteam.domumornamentum.jei;
+
+import com.ldtteam.domumornamentum.IDomumOrnamentumApi;
+import com.ldtteam.domumornamentum.block.IModBlocks;
+import com.ldtteam.domumornamentum.recipe.ModRecipeSerializers;
+import com.ldtteam.domumornamentum.recipe.ModRecipeTypes;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.registration.*;
+import mezz.jei.api.runtime.IIngredientManager;
+import mezz.jei.api.runtime.IJeiRuntime;
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeManager;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static com.ldtteam.domumornamentum.util.Constants.MOD_ID;
+
+@JeiPlugin
+public class JEIPlugin implements IModPlugin
+{
+    private IIngredientManager ingredientManager;
+
+    @Nullable
+    public IIngredientManager getIngredientManager()
+    {
+        return this.ingredientManager;
+    }
+
+    @NotNull
+    @Override
+    public ResourceLocation getPluginUid()
+    {
+        return new ResourceLocation(MOD_ID);
+    }
+
+    @Override
+    public void registerItemSubtypes(@NotNull final ISubtypeRegistration registration)
+    {
+        final IModBlocks blocks = IDomumOrnamentumApi.getInstance().getBlocks();
+        final MaterialSubtypeInterpreter interpreter = MaterialSubtypeInterpreter.getInstance();
+
+        registration.registerSubtypeInterpreter(blocks.getDoor().asItem(), interpreter);
+        registration.registerSubtypeInterpreter(blocks.getTrapdoor().asItem(), interpreter);
+        registration.registerSubtypeInterpreter(blocks.getFancyDoor().asItem(), interpreter);
+        registration.registerSubtypeInterpreter(blocks.getFancyTrapdoor().asItem(), interpreter);
+    }
+
+    @Override
+    public void registerCategories(@NotNull final IRecipeCategoryRegistration registration)
+    {
+        final ArchitectsCutterCategory category = new ArchitectsCutterCategory(registration.getJeiHelpers().getGuiHelper(), this);
+        registration.addRecipeCategories(category);
+    }
+
+    @Override
+    public void registerRecipes(@NotNull final IRecipeRegistration registration)
+    {
+        final RecipeManager recipeManager = Minecraft.getInstance().level.getRecipeManager();
+
+        registration.addRecipes(recipeManager.getAllRecipesFor(ModRecipeTypes.ARCHITECTS_CUTTER), ModRecipeSerializers.ARCHITECTS_CUTTER.getRegistryName());
+    }
+
+    @Override
+    public void registerRecipeCatalysts(@NotNull final IRecipeCatalystRegistration registration)
+    {
+        registration.addRecipeCatalyst(
+                new ItemStack(IDomumOrnamentumApi.getInstance().getBlocks().getArchitectsCutter()),
+                ModRecipeSerializers.ARCHITECTS_CUTTER.getRegistryName());
+    }
+
+    @Override
+    public void onRuntimeAvailable(@NotNull final IJeiRuntime jeiRuntime)
+    {
+        this.ingredientManager = jeiRuntime.getIngredientManager();
+    }
+}

--- a/src/main/java/com/ldtteam/domumornamentum/jei/MaterialSubtypeInterpreter.java
+++ b/src/main/java/com/ldtteam/domumornamentum/jei/MaterialSubtypeInterpreter.java
@@ -1,0 +1,26 @@
+package com.ldtteam.domumornamentum.jei;
+
+import mezz.jei.api.ingredients.subtypes.IIngredientSubtypeInterpreter;
+import mezz.jei.api.ingredients.subtypes.UidContext;
+import net.minecraft.world.item.ItemStack;
+
+public class MaterialSubtypeInterpreter implements IIngredientSubtypeInterpreter<ItemStack>
+{
+    private static final MaterialSubtypeInterpreter INSTANCE = new MaterialSubtypeInterpreter();
+    public static MaterialSubtypeInterpreter getInstance() { return INSTANCE; }
+
+    private MaterialSubtypeInterpreter()
+    {
+    }
+
+    @Override
+    public String apply(ItemStack itemStack, UidContext context)
+    {
+        if (!itemStack.hasTag())
+        {
+            return IIngredientSubtypeInterpreter.NONE;
+        }
+
+        return itemStack.getTag().getString("type");
+    }
+}


### PR DESCRIPTION
Adds basic JEI integration (recipe lookup).  No recipe transfer yet but I might do that in a separate PR.

Firstly, this adds all of the cutter block types to the main Domum Ornamentum creative tab (which previously only had the cutter itself on it).  Only one block of each type is added, and each one generates with randomly selected materials each time you connect your client, to keep it interesting.
![image](https://user-images.githubusercontent.com/539951/136403501-38a735a6-3597-418b-a87a-0503b83f99d5.png)

Secondly, this adds basic JEI recipe lookup.  JEI also shows the same random items in its ingredient list on the right, and pressing U on any valid input item (at all, including ones not used by the random visible items) will show all possible usages for that item (in all cutter slots), or you can press R on any cutter item to see all possible input blocks for that output type (in theory, although I think JEI imposes a hard cap of about 100 that it will cycle between).  The output item render updates to match whatever input blocks it is showing at the time.
![image](https://user-images.githubusercontent.com/539951/136403876-3635fa62-48e2-46d4-bb72-a1b75814f1b8.png)
(This will break if you change the cutter's gui texture, so remember to update both at the same time if needed.)