### PR TITLE
Classify all Brick Extras as bricks

### DIFF
--- a/src/datagen/generated/domum_ornamentum/data/domum_ornamentum/tags/blocks/bricks.json
+++ b/src/datagen/generated/domum_ornamentum/data/domum_ornamentum/tags/blocks/bricks.json
@@ -9,5 +9,22 @@
     "domum_ornamentum:beige_stone_bricks",
     "domum_ornamentum:cream_stone_bricks",
     "domum_ornamentum:sand_stone_bricks"
+    "domum_ornamentum:black_brick_extra",
+    "domum_ornamentum:blue_brick_extra",
+    "domum_ornamentum:brown_brick_extra",
+    "domum_ornamentum:brick_extra",
+    "domum_ornamentum:cyan_brick_extra",
+    "domum_ornamentum:gray_brick_extra",
+    "domum_ornamentum:green_brick_extra",
+    "domum_ornamentum:light_blue_brick_extra",
+    "domum_ornamentum:light_gray_brick_extra",
+    "domum_ornamentum:lime_brick_extra",
+    "domum_ornamentum:magenta_brick_extra",
+    "domum_ornamentum:orange_brick_extra",
+    "domum_ornamentum:pink_brick_extra",
+    "domum_ornamentum:purple_brick_extra",
+    "domum_ornamentum:red_brick_extra",
+    "domum_ornamentum:white_brick_extra",
+    "domum_ornamentum:yellow_brick_extra",
   ]
 }


### PR DESCRIPTION
A discussion on Discord indicated this wasn’t very popular with the two people online at the moment who discussed it, so I don’t know if this should be rejected.  But I find it confusing to be told to consult [the path block list](https://github.com/ldtteam/minecolonies/blob/version/1.18/src/datagen/generated/minecolonies/data/minecolonies/tags/blocks/pathblocks.json) which contains `#domum_ornamentum:bricks`, only to find that of the 25 blocks called “bricks” in DO, only 8 of them count.

My initial motivation for trying is that I want more colorful path block options, but that can be added by making wool an official path block in the minecolonies repo (which I would argue is a good idea *anyway* at least for 1.19, where vanilla structures include wool paths) or by adding floating carpets to the list, neither of which needs to be addressed *here* if this change isn’t accepted.