### PR TITLE
Sound type improvements

### DIFF
--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/BrickBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/BrickBlock.java
@@ -2,6 +2,7 @@ package com.ldtteam.domumornamentum.block.decorative;
 
 import com.ldtteam.domumornamentum.block.AbstractBlock;
 import com.ldtteam.domumornamentum.block.types.BrickType;
+import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.material.Material;
 
 /**
@@ -29,7 +30,7 @@ public class BrickBlock extends AbstractBlock<BrickBlock>
      */
     public BrickBlock(final BrickType type)
     {
-        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE));
+        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).sound(SoundType.STONE));
         this.type = type;
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ExtraBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ExtraBlock.java
@@ -26,7 +26,7 @@ public class ExtraBlock extends AbstractBlock<ExtraBlock>
      */
     public ExtraBlock(final ExtraBlockType type)
     {
-        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE));
+        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).sound(type.getSoundType()));
         this.type = type;
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
@@ -20,6 +20,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -27,6 +28,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.SoundType;
@@ -170,6 +172,16 @@ public class FancyDoorBlock extends AbstractBlockDoor<FancyDoorBlock> implements
     public void resetCache()
     {
         fillItemGroupCache.clear();
+    }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
@@ -20,6 +20,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -27,6 +28,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.SoundType;
@@ -158,6 +160,16 @@ public class FancyTrapdoorBlock extends AbstractBlockTrapdoor<FancyTrapdoorBlock
     public @NotNull Block getBlock()
     {
         return this;
+    }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PanelBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PanelBlock.java
@@ -17,6 +17,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -24,6 +25,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.SoundType;
@@ -152,6 +154,16 @@ public class PanelBlock extends AbstractPanelBlockTrapdoor<PanelBlock> implement
     public @NotNull Block getBlock()
     {
         return this;
+    }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PaperWallBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PaperWallBlock.java
@@ -19,6 +19,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -27,10 +28,12 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -168,6 +171,16 @@ public class PaperWallBlock extends AbstractBlockPane<PaperWallBlock> implements
     public @NotNull Block getBlock()
     {
         return this;
+    }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
     }
 
     @NotNull

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PillarBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PillarBlock.java
@@ -17,6 +17,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -25,9 +26,11 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
@@ -339,6 +342,16 @@ public class PillarBlock extends AbstractBlock<PillarBlock> implements IMaterial
 
     @Override
     public @NotNull Block getBlock() { return this; }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
+    }
 
     @NotNull
     public Collection<FinishedRecipe> getValidCutterRecipes()

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleBlock.java
@@ -20,6 +20,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -27,9 +28,11 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.StairsShape;
@@ -161,6 +164,15 @@ public class ShingleBlock extends AbstractBlockStairs<ShingleBlock> implements I
         return this;
     }
 
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(1).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
+    }
 
     @NotNull
     public Collection<FinishedRecipe> getValidCutterRecipes() {

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleSlabBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleSlabBlock.java
@@ -22,6 +22,7 @@ import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.FluidTags;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -31,10 +32,12 @@ import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.SimpleWaterloggedBlock;
+import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -352,6 +355,15 @@ public class ShingleSlabBlock extends AbstractBlockDirectional<ShingleSlabBlock>
         return this;
     }
 
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @org.jetbrains.annotations.Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(1).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
+    }
 
     @NotNull
     public Collection<FinishedRecipe> getValidCutterRecipes() {

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/TimberFrameBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/TimberFrameBlock.java
@@ -20,6 +20,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -28,6 +29,7 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -196,6 +198,15 @@ public class TimberFrameBlock extends AbstractBlock<TimberFrameBlock> implements
         return this;
     }
 
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
+    }
 
     @NotNull
     public Collection<FinishedRecipe> getValidCutterRecipes() {

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/ExtraBlockType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/ExtraBlockType.java
@@ -4,6 +4,7 @@ import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.SoundType;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -13,41 +14,43 @@ import org.jetbrains.annotations.Nullable;
  */
 public enum ExtraBlockType implements StringRepresentable
 {
-    BLACK_CLAY(DyeColor.BLACK, Items.BRICK),
-    BLUE_CLAY(DyeColor.BLUE, Items.BRICK),
-    BLUE_SLATE(DyeColor.BLUE, Items.COBBLESTONE),
-    BROWN_CLAY(DyeColor.BROWN, Items.BRICK),
-    BASE_CLAY(null, Items.BRICK),
-    CYAN_CLAY(DyeColor.CYAN, Items.BRICK),
-    GRAY_CLAY(DyeColor.GRAY, Items.BRICK),
-    GREEN_CLAY(DyeColor.GREEN, Items.BRICK),
-    GREEN_SLATE(DyeColor.GREEN, Items.COBBLESTONE),
-    LIGHT_BLUE_CLAY(DyeColor.LIGHT_BLUE, Items.BRICK),
-    LIGHT_GRAY_CLAY(DyeColor.LIGHT_GRAY, Items.BRICK),
-    LIME_CLAY(DyeColor.LIME, Items.BRICK),
-    MAGENTA_CLAY(DyeColor.MAGENTA, Items.BRICK),
-    MOSS_SLATE(null, Items.MOSSY_COBBLESTONE),
-    ORANGE_CLAY(DyeColor.ORANGE, Items.BRICK),
-    PINK_CLAY(DyeColor.PINK, Items.BRICK),
-    PURPLE_CLAY(DyeColor.PURPLE, Items.BRICK),
-    PURPLE_SLATE(DyeColor.PURPLE, Items.COBBLESTONE),
-    RED_CLAY(DyeColor.RED, Items.BRICK),
-    BASE_SLATE(null, Items.COBBLESTONE),
-    BASE_THATCHED(null, Items.WHEAT),
-    WHITE_CLAY(DyeColor.WHITE, Items.BRICK),
-    YELLOW_CLAY(DyeColor.YELLOW, Items.BRICK),
-    BASE_PAPER(null, Items.PAPER),
-    BASE_CACTUS(null, Items.CACTUS),
-    GREEN_CACTUS(DyeColor.GREEN, Items.CACTUS),
-    LIGHT_PAPER(DyeColor.WHITE, Items.PAPER);
+    BLACK_CLAY(DyeColor.BLACK, Items.BRICK, SoundType.STONE),
+    BLUE_CLAY(DyeColor.BLUE, Items.BRICK, SoundType.STONE),
+    BLUE_SLATE(DyeColor.BLUE, Items.COBBLESTONE, SoundType.STONE),
+    BROWN_CLAY(DyeColor.BROWN, Items.BRICK, SoundType.STONE),
+    BASE_CLAY(null, Items.BRICK, SoundType.STONE),
+    CYAN_CLAY(DyeColor.CYAN, Items.BRICK, SoundType.STONE),
+    GRAY_CLAY(DyeColor.GRAY, Items.BRICK, SoundType.STONE),
+    GREEN_CLAY(DyeColor.GREEN, Items.BRICK, SoundType.STONE),
+    GREEN_SLATE(DyeColor.GREEN, Items.COBBLESTONE, SoundType.STONE),
+    LIGHT_BLUE_CLAY(DyeColor.LIGHT_BLUE, Items.BRICK, SoundType.STONE),
+    LIGHT_GRAY_CLAY(DyeColor.LIGHT_GRAY, Items.BRICK, SoundType.STONE),
+    LIME_CLAY(DyeColor.LIME, Items.BRICK, SoundType.STONE),
+    MAGENTA_CLAY(DyeColor.MAGENTA, Items.BRICK, SoundType.STONE),
+    MOSS_SLATE(null, Items.MOSSY_COBBLESTONE, SoundType.STONE),
+    ORANGE_CLAY(DyeColor.ORANGE, Items.BRICK, SoundType.STONE),
+    PINK_CLAY(DyeColor.PINK, Items.BRICK, SoundType.STONE),
+    PURPLE_CLAY(DyeColor.PURPLE, Items.BRICK, SoundType.STONE),
+    PURPLE_SLATE(DyeColor.PURPLE, Items.COBBLESTONE, SoundType.STONE),
+    RED_CLAY(DyeColor.RED, Items.BRICK, SoundType.STONE),
+    BASE_SLATE(null, Items.COBBLESTONE, SoundType.STONE),
+    BASE_THATCHED(null, Items.WHEAT, SoundType.GRASS),
+    WHITE_CLAY(DyeColor.WHITE, Items.BRICK, SoundType.STONE),
+    YELLOW_CLAY(DyeColor.YELLOW, Items.BRICK, SoundType.STONE),
+    BASE_PAPER(null, Items.PAPER, SoundType.WOOL),
+    BASE_CACTUS(null, Items.CACTUS, SoundType.WOOD),
+    GREEN_CACTUS(DyeColor.GREEN, Items.CACTUS, SoundType.WOOD),
+    LIGHT_PAPER(DyeColor.WHITE, Items.PAPER, SoundType.WOOL);
 
     private final DyeColor color;
     private final Item material;
+    private final SoundType soundType;
 
-    ExtraBlockType(final DyeColor color, final Item material)
+    ExtraBlockType(final DyeColor color, final Item material, final SoundType soundType)
     {
         this.color = color;
         this.material = material;
+        this.soundType = soundType;
     }
 
     @NotNull
@@ -66,5 +69,9 @@ public enum ExtraBlockType implements StringRepresentable
     public Item getMaterial()
     {
         return this.material;
+    }
+
+    public SoundType getSoundType() {
+        return this.soundType;
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
@@ -20,6 +20,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -27,6 +28,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.SoundType;
@@ -169,6 +171,16 @@ public class DoorBlock extends AbstractBlockDoor<DoorBlock> implements IMaterial
     public @NotNull Block getBlock()
     {
         return this;
+    }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceBlock.java
@@ -16,12 +16,14 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.SoundType;
@@ -120,5 +122,15 @@ public class FenceBlock extends AbstractBlockFence<FenceBlock> implements IMater
     public Block getBlock()
     {
         return this;
+    }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceGateBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceGateBlock.java
@@ -16,12 +16,14 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.SoundType;
@@ -119,5 +121,15 @@ public class FenceGateBlock extends AbstractBlockFenceGate<FenceGateBlock> imple
     public @NotNull Block getBlock()
     {
         return this;
+    }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/SlabBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/SlabBlock.java
@@ -19,6 +19,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -26,6 +27,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.SoundType;
@@ -127,6 +129,16 @@ public class SlabBlock extends AbstractBlockSlab<SlabBlock> implements IMaterial
     public @NotNull Block getBlock()
     {
         return this;
+    }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
     }
 
     @NotNull

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/StairBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/StairBlock.java
@@ -29,6 +29,7 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
@@ -214,5 +215,15 @@ public class StairBlock extends AbstractBlockStairs<StairBlock> implements IMate
     public @NotNull Block getBlock()
     {
         return this;
+    }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
@@ -20,6 +20,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -27,6 +28,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.SoundType;
@@ -159,6 +161,16 @@ public class TrapdoorBlock extends AbstractBlockTrapdoor<TrapdoorBlock> implemen
     public @NotNull Block getBlock()
     {
         return this;
+    }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/WallBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/WallBlock.java
@@ -16,12 +16,14 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.SoundType;
@@ -118,5 +120,15 @@ public class WallBlock extends AbstractBlockWall<WallBlock> implements IMaterial
     public @NotNull Block getBlock()
     {
         return this;
+    }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
     }
 }


### PR DESCRIPTION
This PR:
- changes all blocks craftable in the cutter to use the sound type of the block they are made of (previously used either stone or wood sounds)
- changes the sound type of the brown, beige, cream and sand bricks to stone (previously used wood sounds)
- changes the sound type of cactus extra and green cactus extra to wood (previously used stone sounds)
- changes the sound type of paper extra and white paper extra to wool (previously used stone sounds)
- changes the sound type of wheat extra to grass (previously used stone sounds)
