### PR TITLE
Port JEI integration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,8 @@ minecraftVersion=1.19
 exactMinecraftVersion=1.19
 additionalMinecraftVersions=1.19;1.19.2
 
-jei_version=9.4.1.116
+jei_mcversion=1.19
+jei_version=11.1.1.239
 
 mappingsChannel=official
 mappingsVersion=1.19

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,9 @@ minecraft.runs.all {
 }
 
 dependencies {
-    //implementation fg.deobf("mezz.jei:jei-1.18.2:${project.jei_version}")
+    compileOnly fg.deobf("mezz.jei:jei-${project.jei_mcversion}-common-api:${project.jei_version}")
+    compileOnly fg.deobf("mezz.jei:jei-${project.jei_mcversion}-forge-api:${project.jei_version}")
+    runtimeOnly fg.deobf("mezz.jei:jei-${project.jei_mcversion}-forge:${project.jei_version}")
 
     apiLibrary ("com.ldtteam:datagenerators:${project.dataGeneratorsVersion}") {
         transitive = false

--- a/src/main/java/com/ldtteam/domumornamentum/jei/JEIPlugin.java
+++ b/src/main/java/com/ldtteam/domumornamentum/jei/JEIPlugin.java
@@ -1,11 +1,11 @@
 package com.ldtteam.domumornamentum.jei;
-/*
 import com.ldtteam.domumornamentum.IDomumOrnamentumApi;
 import com.ldtteam.domumornamentum.block.IModBlocks;
 import com.ldtteam.domumornamentum.recipe.ModRecipeSerializers;
 import com.ldtteam.domumornamentum.recipe.ModRecipeTypes;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.registration.*;
 import mezz.jei.api.runtime.IIngredientManager;
 import mezz.jei.api.runtime.IJeiRuntime;
@@ -60,15 +60,15 @@ public class JEIPlugin implements IModPlugin
     {
         final RecipeManager recipeManager = Minecraft.getInstance().level.getRecipeManager();
 
-        registration.addRecipes(recipeManager.getAllRecipesFor(ModRecipeTypes.ARCHITECTS_CUTTER), ModRecipeSerializers.ARCHITECTS_CUTTER.getRegistryName());
+        registration.addRecipes(ArchitectsCutterCategory.TYPE, recipeManager.getAllRecipesFor(ModRecipeTypes.ARCHITECTS_CUTTER.get()));
     }
 
     @Override
     public void registerRecipeCatalysts(@NotNull final IRecipeCatalystRegistration registration)
     {
-        registration.addRecipeCatalyst(
+        registration.addRecipeCatalyst(VanillaTypes.ITEM_STACK,
                 new ItemStack(IDomumOrnamentumApi.getInstance().getBlocks().getArchitectsCutter()),
-                ModRecipeSerializers.ARCHITECTS_CUTTER.getRegistryName());
+                ArchitectsCutterCategory.TYPE);
     }
 
     @Override
@@ -77,4 +77,3 @@ public class JEIPlugin implements IModPlugin
         this.ingredientManager = jeiRuntime.getIngredientManager();
     }
 }
-*/

--- a/src/main/java/com/ldtteam/domumornamentum/jei/MaterialSubtypeInterpreter.java
+++ b/src/main/java/com/ldtteam/domumornamentum/jei/MaterialSubtypeInterpreter.java
@@ -1,8 +1,8 @@
 package com.ldtteam.domumornamentum.jei;
-/*
 import mezz.jei.api.ingredients.subtypes.IIngredientSubtypeInterpreter;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
 public class MaterialSubtypeInterpreter implements IIngredientSubtypeInterpreter<ItemStack>
 {
@@ -13,8 +13,10 @@ public class MaterialSubtypeInterpreter implements IIngredientSubtypeInterpreter
     {
     }
 
+    @NotNull
     @Override
-    public String apply(ItemStack itemStack, UidContext context)
+    public String apply(@NotNull final ItemStack itemStack,
+                        @NotNull final UidContext context)
     {
         if (!itemStack.hasTag())
         {
@@ -24,5 +26,3 @@ public class MaterialSubtypeInterpreter implements IIngredientSubtypeInterpreter
         return itemStack.getTag().getString("type");
     }
 }
-*/
-


### PR DESCRIPTION
- Ports and updates the JEI integration to 1.19, since that was left disabled
   - Functionality should be the same as before
- I haven't inspected/changed the subtype interpreters since I'm not sure what they're needed for -- I *think* it's still displaying all the block types regardless...