### PR TITLE
Mining and explosion resistance for DO blocks

### DIFF
--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/BrickBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/BrickBlock.java
@@ -30,7 +30,7 @@ public class BrickBlock extends AbstractBlock<BrickBlock>
      */
     public BrickBlock(final BrickType type)
     {
-        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).sound(SoundType.STONE));
+        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).requiresCorrectToolForDrops().sound(SoundType.STONE));
         this.type = type;
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ExtraBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ExtraBlock.java
@@ -26,7 +26,7 @@ public class ExtraBlock extends AbstractBlock<ExtraBlock>
      */
     public ExtraBlock(final ExtraBlockType type)
     {
-        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).sound(type.getSoundType()));
+        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).requiresCorrectToolForDrops().sound(type.getSoundType()));
         this.type = type;
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
@@ -65,7 +65,7 @@ public class FancyDoorBlock extends AbstractBlockDoor<FancyDoorBlock> implements
 
     public FancyDoorBlock()
     {
-        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(3.0F).sound(SoundType.WOOD).noOcclusion().isValidSpawn((state, blockGetter, pos, type) -> false));
+        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(3.0F).requiresCorrectToolForDrops().sound(SoundType.WOOD).noOcclusion().isValidSpawn((state, blockGetter, pos, type) -> false));
         this.registerDefaultState(this.defaultBlockState().setValue(TYPE, FancyDoorType.FULL));
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
@@ -11,7 +11,6 @@ import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
 import com.ldtteam.domumornamentum.block.types.FancyDoorType;
 import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
-import com.ldtteam.domumornamentum.entity.block.ModBlockEntityTypes;
 import com.ldtteam.domumornamentum.recipe.ModRecipeSerializers;
 import com.ldtteam.domumornamentum.tag.ModTags;
 import com.ldtteam.domumornamentum.util.BlockUtils;
@@ -23,10 +22,10 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -44,7 +43,11 @@ import net.minecraft.world.phys.HitResult;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 import static net.minecraft.world.level.block.Blocks.ACACIA_PLANKS;
 import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
@@ -77,6 +80,16 @@ public class FancyDoorBlock extends AbstractBlockDoor<FancyDoorBlock> implements
     public @NotNull Block getBlock()
     {
         return this;
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
@@ -93,6 +93,16 @@ public class FancyDoorBlock extends AbstractBlockDoor<FancyDoorBlock> implements
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
@@ -87,6 +87,16 @@ public class FancyTrapdoorBlock extends AbstractBlockTrapdoor<FancyTrapdoorBlock
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
@@ -27,6 +27,7 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -73,6 +74,16 @@ public class FancyTrapdoorBlock extends AbstractBlockTrapdoor<FancyTrapdoorBlock
     {
         super.createBlockStateDefinition(builder);
         builder.add(TYPE);
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
@@ -65,7 +65,7 @@ public class FancyTrapdoorBlock extends AbstractBlockTrapdoor<FancyTrapdoorBlock
 
     public FancyTrapdoorBlock()
     {
-        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(3.0F).sound(SoundType.WOOD).noOcclusion().isValidSpawn((state, blockGetter, pos, type) -> false));
+        super(Properties.of(Material.WOOD, MaterialColor.WOOD).requiresCorrectToolForDrops().strength(3.0F).sound(SoundType.WOOD).noOcclusion().isValidSpawn((state, blockGetter, pos, type) -> false));
         this.registerDefaultState(this.defaultBlockState().setValue(TYPE, FancyTrapdoorType.FULL));
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FramedLightBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FramedLightBlock.java
@@ -19,6 +19,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
@@ -26,7 +27,9 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -88,6 +91,16 @@ public class FramedLightBlock extends AbstractBlock<FramedLightBlock> implements
     public @NotNull PushReaction getPistonPushReaction(final BlockState state)
     {
         return PushReaction.PUSH_ONLY;
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override
@@ -210,5 +223,15 @@ public class FramedLightBlock extends AbstractBlock<FramedLightBlock> implements
               }
           }
         );
+    }
+
+    @Override
+    public SoundType getSoundType(BlockState state, LevelReader level, BlockPos pos, @Nullable Entity entity) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getSoundType(state, level, pos, entity);
+        }
+        return super.getSoundType(state, level, pos, entity);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FramedLightBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FramedLightBlock.java
@@ -104,6 +104,16 @@ public class FramedLightBlock extends AbstractBlock<FramedLightBlock> implements
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FramedLightBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FramedLightBlock.java
@@ -78,7 +78,7 @@ public class FramedLightBlock extends AbstractBlock<FramedLightBlock> implements
      */
     public FramedLightBlock(final FramedLightType framedLightType)
     {
-        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).noOcclusion().lightLevel(state -> 15));
+        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).requiresCorrectToolForDrops().noOcclusion().lightLevel(state -> 15));
         this.framedLightType = framedLightType;
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PanelBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PanelBlock.java
@@ -82,6 +82,16 @@ public class PanelBlock extends AbstractPanelBlockTrapdoor<PanelBlock> implement
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PanelBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PanelBlock.java
@@ -24,6 +24,7 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -68,6 +69,16 @@ public class PanelBlock extends AbstractPanelBlockTrapdoor<PanelBlock> implement
     {
         super.createBlockStateDefinition(builder);
         builder.add(TYPE);
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PanelBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PanelBlock.java
@@ -60,7 +60,7 @@ public class PanelBlock extends AbstractPanelBlockTrapdoor<PanelBlock> implement
 
     public PanelBlock()
     {
-        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(3.0F).sound(SoundType.WOOD).noOcclusion().isValidSpawn((state, blockGetter, pos, type) -> false));
+        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(3.0F).requiresCorrectToolForDrops().sound(SoundType.WOOD).noOcclusion().isValidSpawn((state, blockGetter, pos, type) -> false));
         this.registerDefaultState(this.defaultBlockState().setValue(TYPE, TrapdoorType.FULL));
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PaperWallBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PaperWallBlock.java
@@ -72,7 +72,7 @@ public class PaperWallBlock extends AbstractBlockPane<PaperWallBlock> implements
 
     public PaperWallBlock()
     {
-        super(Properties.of(Material.GLASS).strength(BLOCK_HARDNESS, RESISTANCE));
+        super(Properties.of(Material.GLASS).strength(BLOCK_HARDNESS, RESISTANCE).requiresCorrectToolForDrops());
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PaperWallBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PaperWallBlock.java
@@ -109,6 +109,16 @@ public class PaperWallBlock extends AbstractBlockPane<PaperWallBlock> implements
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PaperWallBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PaperWallBlock.java
@@ -26,6 +26,7 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
@@ -95,6 +96,16 @@ public class PaperWallBlock extends AbstractBlockPane<PaperWallBlock> implements
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
         builder.add(NORTH, EAST, WEST, SOUTH, WATERLOGGED);
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PillarBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PillarBlock.java
@@ -120,6 +120,16 @@ public class PillarBlock extends AbstractBlock<PillarBlock> implements IMaterial
         return super.getExplosionResistance(state, level, pos, explosion);
     }
 
+    @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
     /**
      * Finds the correct blockstate on placement by checking the blocks above and below the clicked position from the context. Then calls updateAbove and upDateBelow
      * to correct their blockstates based on their upper/lower neighbor and this block.

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PillarBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PillarBlock.java
@@ -24,6 +24,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -107,6 +108,16 @@ public class PillarBlock extends AbstractBlock<PillarBlock> implements IMaterial
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder)
     {
         builder.add(COLUMN);
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     /**

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PillarBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PillarBlock.java
@@ -82,7 +82,7 @@ public class PillarBlock extends AbstractBlock<PillarBlock> implements IMaterial
      */
     public PillarBlock()
     {
-        super(BlockBehaviour.Properties.of(Material.STONE).strength(BLOCK_HARDNESS, RESISTANCE));
+        super(BlockBehaviour.Properties.of(Material.STONE).strength(BLOCK_HARDNESS, RESISTANCE).requiresCorrectToolForDrops());
         this.registerDefaultState(this.stateDefinition.any().setValue(COLUMN,PillarShapeType.FULL_PILLAR));
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleBlock.java
@@ -106,6 +106,16 @@ public class ShingleBlock extends AbstractBlockStairs<ShingleBlock> implements I
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(1).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleBlock.java
@@ -71,7 +71,7 @@ public class ShingleBlock extends AbstractBlockStairs<ShingleBlock> implements I
 
     public ShingleBlock()
     {
-        super(Blocks.OAK_PLANKS::defaultBlockState, Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).noOcclusion());
+        super(Blocks.OAK_PLANKS::defaultBlockState, Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).requiresCorrectToolForDrops().noOcclusion());
     }
 
     /**

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleBlock.java
@@ -27,6 +27,7 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -92,6 +93,16 @@ public class ShingleBlock extends AbstractBlockStairs<ShingleBlock> implements I
             default:
                 return ShingleShapeType.STRAIGHT;
         }
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(1).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleSlabBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleSlabBlock.java
@@ -109,7 +109,7 @@ public class ShingleSlabBlock extends AbstractBlockDirectional<ShingleSlabBlock>
      */
     public ShingleSlabBlock()
     {
-        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE));
+        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).requiresCorrectToolForDrops());
         registerDefaultState(defaultBlockState().setValue(WATERLOGGED, false));
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleSlabBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleSlabBlock.java
@@ -296,6 +296,16 @@ public class ShingleSlabBlock extends AbstractBlockDirectional<ShingleSlabBlock>
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(1).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleSlabBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleSlabBlock.java
@@ -30,6 +30,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
@@ -282,6 +283,16 @@ public class ShingleSlabBlock extends AbstractBlockDirectional<ShingleSlabBlock>
     protected void createBlockStateDefinition(final StateDefinition.Builder<Block, BlockState> builder)
     {
         builder.add(FACING, SHAPE, WATERLOGGED);
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(1).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/TimberFrameBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/TimberFrameBlock.java
@@ -29,6 +29,7 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.*;
@@ -128,6 +129,16 @@ public class TimberFrameBlock extends AbstractBlock<TimberFrameBlock> implements
 
     public BlockState getStateForPlacement(BlockPlaceContext context) {
         return this.defaultBlockState().setValue(FACING, context.getNearestLookingDirection().getOpposite());
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/TimberFrameBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/TimberFrameBlock.java
@@ -85,7 +85,7 @@ public class TimberFrameBlock extends AbstractBlock<TimberFrameBlock> implements
      */
     public TimberFrameBlock(final TimberFrameType timberFrameType)
     {
-        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).noOcclusion());
+        super(Properties.of(Material.WOOD).strength(BLOCK_HARDNESS, RESISTANCE).requiresCorrectToolForDrops().noOcclusion());
         this.timberFrameType = timberFrameType;
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/TimberFrameBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/TimberFrameBlock.java
@@ -142,6 +142,16 @@ public class TimberFrameBlock extends AbstractBlock<TimberFrameBlock> implements
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
@@ -84,6 +84,16 @@ public class DoorBlock extends AbstractBlockDoor<DoorBlock> implements IMaterial
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
@@ -62,7 +62,7 @@ public class DoorBlock extends AbstractBlockDoor<DoorBlock> implements IMaterial
 
     public DoorBlock()
     {
-        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(3.0F).sound(SoundType.WOOD).noOcclusion().isValidSpawn((state, blockGetter, pos, type) -> false));
+        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(3.0F).requiresCorrectToolForDrops().sound(SoundType.WOOD).noOcclusion().isValidSpawn((state, blockGetter, pos, type) -> false));
         this.registerDefaultState(this.defaultBlockState().setValue(TYPE, DoorType.FULL));
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
@@ -27,6 +27,7 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -70,6 +71,16 @@ public class DoorBlock extends AbstractBlockDoor<DoorBlock> implements IMaterial
     {
         super.createBlockStateDefinition(builder);
         builder.add(TYPE);
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceBlock.java
@@ -22,6 +22,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -51,6 +52,16 @@ public class FenceBlock extends AbstractBlockFence<FenceBlock> implements IMater
     public FenceBlock()
     {
         super(BlockBehaviour.Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).strength(2.0F, 3.0F).sound(SoundType.WOOD));
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceBlock.java
@@ -51,7 +51,7 @@ public class FenceBlock extends AbstractBlockFence<FenceBlock> implements IMater
 
     public FenceBlock()
     {
-        super(BlockBehaviour.Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).strength(2.0F, 3.0F).sound(SoundType.WOOD));
+        super(BlockBehaviour.Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).strength(2.0F, 3.0F).requiresCorrectToolForDrops().sound(SoundType.WOOD));
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceBlock.java
@@ -65,6 +65,16 @@ public class FenceBlock extends AbstractBlockFence<FenceBlock> implements IMater
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceGateBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceGateBlock.java
@@ -22,6 +22,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -50,6 +51,16 @@ public class FenceGateBlock extends AbstractBlockFenceGate<FenceGateBlock> imple
     public FenceGateBlock()
     {
         super(Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).strength(2.0F, 3.0F).sound(SoundType.WOOD));
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceGateBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceGateBlock.java
@@ -64,6 +64,16 @@ public class FenceGateBlock extends AbstractBlockFenceGate<FenceGateBlock> imple
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceGateBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceGateBlock.java
@@ -50,7 +50,7 @@ public class FenceGateBlock extends AbstractBlockFenceGate<FenceGateBlock> imple
 
     public FenceGateBlock()
     {
-        super(Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).strength(2.0F, 3.0F).sound(SoundType.WOOD));
+        super(Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).strength(2.0F, 3.0F).requiresCorrectToolForDrops().sound(SoundType.WOOD));
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/SlabBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/SlabBlock.java
@@ -71,6 +71,16 @@ public class SlabBlock extends AbstractBlockSlab<SlabBlock> implements IMaterial
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/SlabBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/SlabBlock.java
@@ -57,7 +57,7 @@ public class SlabBlock extends AbstractBlockSlab<SlabBlock> implements IMaterial
 
     public SlabBlock()
     {
-        super(BlockBehaviour.Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).noOcclusion().strength(2.0F, 3.0F).sound(SoundType.WOOD));
+        super(BlockBehaviour.Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).noOcclusion().strength(2.0F, 3.0F).requiresCorrectToolForDrops().sound(SoundType.WOOD));
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/SlabBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/SlabBlock.java
@@ -26,6 +26,7 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -57,6 +58,16 @@ public class SlabBlock extends AbstractBlockSlab<SlabBlock> implements IMaterial
     public SlabBlock()
     {
         super(BlockBehaviour.Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).noOcclusion().strength(2.0F, 3.0F).sound(SoundType.WOOD));
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/StairBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/StairBlock.java
@@ -59,7 +59,7 @@ public class StairBlock extends AbstractBlockStairs<StairBlock> implements IMate
 
     public StairBlock()
     {
-        super(OAK_PLANKS::defaultBlockState, Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).noOcclusion().strength(2.0F, 3.0F).sound(SoundType.WOOD));
+        super(OAK_PLANKS::defaultBlockState, Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).noOcclusion().strength(2.0F, 3.0F).requiresCorrectToolForDrops().sound(SoundType.WOOD));
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/StairBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/StairBlock.java
@@ -63,6 +63,16 @@ public class StairBlock extends AbstractBlockStairs<StairBlock> implements IMate
     }
 
     @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/StairBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/StairBlock.java
@@ -73,6 +73,16 @@ public class StairBlock extends AbstractBlockStairs<StairBlock> implements IMate
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
@@ -27,6 +27,7 @@ import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -71,6 +72,16 @@ public class TrapdoorBlock extends AbstractBlockTrapdoor<TrapdoorBlock> implemen
     {
         super.createBlockStateDefinition(builder);
         builder.add(TYPE);
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
@@ -85,6 +85,16 @@ public class TrapdoorBlock extends AbstractBlockTrapdoor<TrapdoorBlock> implemen
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
@@ -63,7 +63,7 @@ public class TrapdoorBlock extends AbstractBlockTrapdoor<TrapdoorBlock> implemen
 
     public TrapdoorBlock()
     {
-        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(3.0F).sound(SoundType.WOOD).noOcclusion().isValidSpawn((state, blockGetter, pos, type) -> false));
+        super(Properties.of(Material.WOOD, MaterialColor.WOOD).strength(3.0F).requiresCorrectToolForDrops().sound(SoundType.WOOD).noOcclusion().isValidSpawn((state, blockGetter, pos, type) -> false));
         this.registerDefaultState(this.defaultBlockState().setValue(TYPE, TrapdoorType.FULL));
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/WallBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/WallBlock.java
@@ -76,6 +76,16 @@ public class WallBlock extends AbstractBlockWall<WallBlock> implements IMaterial
     }
 
     @Override
+    public float getDestroyProgress(BlockState state, Player player, BlockGetter level, BlockPos pos) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return super.getDestroyProgress(block.defaultBlockState(), player, level, pos);
+        }
+        return super.getDestroyProgress(state, player, level, pos);
+    }
+
+    @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
         return COMPONENTS;

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/WallBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/WallBlock.java
@@ -62,7 +62,7 @@ public class WallBlock extends AbstractBlockWall<WallBlock> implements IMaterial
 
     public WallBlock()
     {
-        super(Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).strength(2.0F, 3.0F).sound(SoundType.WOOD));
+        super(Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).strength(2.0F, 3.0F).requiresCorrectToolForDrops().sound(SoundType.WOOD));
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/WallBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/WallBlock.java
@@ -24,6 +24,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
@@ -62,6 +63,16 @@ public class WallBlock extends AbstractBlockWall<WallBlock> implements IMaterial
     public WallBlock()
     {
         super(Properties.of(Material.WOOD, OAK_PLANKS.defaultMaterialColor()).strength(2.0F, 3.0F).sound(SoundType.WOOD));
+    }
+
+    @Override
+    public float getExplosionResistance(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion) {
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof MateriallyTexturedBlockEntity mtbe) {
+            Block block = mtbe.getTextureData().getTexturedComponents().get(COMPONENTS.get(0).getId());
+            return block.getExplosionResistance(state, level, pos, explosion);
+        }
+        return super.getExplosionResistance(state, level, pos, explosion);
     }
 
     @Override


### PR DESCRIPTION
This PR adds:

- Explosion resistance based on the materials the DO blocks are made of (in the various `getExplosionResistance` overrides)
- Mining resistance based on the materials the DO blocks are made of (part of the various `getDestroyProgress` overrides)
- Tool requirements based on the materials the DO blocks are made of (part of the various `getDestroyProgress` overrides)
  - This also includes whether the block can be mined without a tool or not
- Tool requirements for the brick and extra blocks (previously, they could be mined by hand)
- A fix for an oversight in #90 (I forgot to add the sound type stuff in `FramedLightBlock`)