### PR TITLE
JEI improvements

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,6 +10,7 @@ configurations {
 dependencies {
     implementation fg.deobf("mezz.jei:jei-${project.jei_mcversion}-common-api:${project.jei_version}")
     implementation fg.deobf("mezz.jei:jei-${project.jei_mcversion}-forge-api:${project.jei_version}")
+    runtimeOnly fg.deobf("mezz.jei:jei-${project.jei_mcversion}-forge:${project.jei_version}")
 
     implementation fg.deobf("com.ldtteam:datagenerators:1.19.3-${project.dataGeneratorsVersion}:universal") {
         transitive = false

--- a/src/main/java/com/ldtteam/domumornamentum/Network.java
+++ b/src/main/java/com/ldtteam/domumornamentum/Network.java
@@ -1,0 +1,23 @@
+package com.ldtteam.domumornamentum;
+
+import com.ldtteam.domumornamentum.network.NetworkChannel;
+
+/**
+ * Network singleton.
+ */
+public class Network
+{
+    /**
+     * The network instance.
+     */
+    private static final NetworkChannel network = new NetworkChannel("net-channel");
+
+    /**
+     * Get the network handler.
+     * @return the network handler.
+     */
+    public static NetworkChannel getNetwork()
+    {
+        return network;
+    }
+}

--- a/src/main/java/com/ldtteam/domumornamentum/client/screens/ArchitectsCutterScreen.java
+++ b/src/main/java/com/ldtteam/domumornamentum/client/screens/ArchitectsCutterScreen.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static com.ldtteam.domumornamentum.util.GuiConstants.*;
+
 public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCutterContainer>
 {
     private static final ResourceLocation BACKGROUND_TEXTURE1 = new ResourceLocation(Constants.MOD_ID, "textures/gui/container/architectscutter.png");
@@ -70,8 +72,8 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
     public ArchitectsCutterScreen(ArchitectsCutterContainer containerIn, Inventory playerInv, Component titleIn) {
         super(containerIn, playerInv, titleIn);
         --this.titleLabelY;
-        this.imageWidth = 242;
-        this.imageHeight = 202;
+        this.imageWidth = CUTTER_BG_W;
+        this.imageHeight = CUTTER_BG_H;
     }
 
     @Override
@@ -103,14 +105,14 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
         if (this.menu.getCurrentGroup() != null)
         {
             int sliderOffset1 = (int) (5.0F * this.recipeSliderProgress);
-            graphics.blit(getBackGroundTexture(), guiLeft + 220, guiTop + 40 + sliderOffset1, 0 + (this.canScrollRecipes() ? 0 : 12), 222, 12, 15);
+            graphics.blit(getBackGroundTexture(), guiLeft + CUTTER_SLIDER_X, guiTop + CUTTER_SLIDER_Y + CUTTER_RECIPE_SPACING + sliderOffset1, 0 + (this.canScrollRecipes() ? CUTTER_SLIDER_U_ENABLED : CUTTER_SLIDER_U_DISABLED), CUTTER_SLIDER_V, CUTTER_SLIDER_W, CUTTER_SLIDER_H);
         }
 
         int sliderOffset2 = (int)(5.0F * this.typeSliderProgress);
-        graphics.blit(getBackGroundTexture(), guiLeft + 220, guiTop + 17 + sliderOffset2, 0 + (this.canScrollTypes() ? 0 : 12), 222, 12, 15);
+        graphics.blit(getBackGroundTexture(), guiLeft + CUTTER_SLIDER_X, guiTop + CUTTER_SLIDER_Y + sliderOffset2, 0 + (this.canScrollTypes() ? CUTTER_SLIDER_U_ENABLED : CUTTER_SLIDER_U_DISABLED), CUTTER_SLIDER_V, CUTTER_SLIDER_W, CUTTER_SLIDER_H);
 
-        int recipeAreaLeft = this.leftPos + 8 + 49;
-        int recipeAreaTop = this.topPos + 16;
+        int recipeAreaLeft = this.leftPos + CUTTER_RECIPE_X;
+        int recipeAreaTop = this.topPos + CUTTER_RECIPE_Y;
 
 
         this.drawSlotBackgrounds(graphics);
@@ -127,16 +129,16 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
     protected void renderTooltip(@NotNull GuiGraphics graphics, int x, int y) {
         super.renderTooltip(graphics, x, y);
         {
-            int i = this.leftPos + 8 + 49;
-            int j = this.topPos + 16;
+            int i = this.leftPos + CUTTER_RECIPE_X;
+            int j = this.topPos + CUTTER_RECIPE_Y;
             int k = this.typeIndexOffset + 10;
             final List<ResourceLocation> list = new ArrayList<>(ModBlocks.getInstance().getOrComputeItemGroups().keySet());
             for (int l = this.typeIndexOffset; l < k && l < list.size(); ++l)
             {
                 int i1 = l - this.typeIndexOffset;
-                int j1 = i + i1 % 10 * 16;
-                int k1 = j + i1 / 10 * 18 + 2;
-                if (x >= j1 && x < j1 + 16 && y >= k1 && y < k1 + 18)
+                int j1 = i + i1 % 10 * CUTTER_RECIPE_W;
+                int k1 = j + i1 / 10 * CUTTER_RECIPE_H + 2;
+                if (x >= j1 && x < j1 + CUTTER_RECIPE_W && y >= k1 && y < k1 + CUTTER_RECIPE_H)
                 {
                     graphics.renderTooltip(this.font, Component.translatable("cuttergroup." + list.get(l).getNamespace() + "." + list.get(l).getPath()), x, y);
                 }
@@ -146,15 +148,15 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
         if (this.menu.getCurrentGroup() != null)
         {
             List<ItemStack> list = ModBlocks.getInstance().getOrComputeItemGroups().get(this.menu.getCurrentGroup());
-            int i = this.leftPos + 8 + 49;
-            int j = this.topPos + 16 + 23;
+            int i = this.leftPos + CUTTER_RECIPE_X;
+            int j = this.topPos + CUTTER_RECIPE_Y + CUTTER_RECIPE_SPACING;
             int k = this.recipeIndexOffset + 10;
 
             for(int l = this.recipeIndexOffset; l < k && l < list.size(); ++l) {
                 int i1 = l - this.recipeIndexOffset;
-                int j1 = i + i1 % 10 * 16;
-                int k1 = j + i1 / 10 * 18 + 2;
-                if (x >= j1 && x < j1 + 16 && y >= k1 && y < k1 + 18) {
+                int j1 = i + i1 % 10 * CUTTER_RECIPE_W;
+                int k1 = j + i1 / 10 * CUTTER_RECIPE_H + 2;
+                if (x >= j1 && x < j1 + CUTTER_RECIPE_W && y >= k1 && y < k1 + CUTTER_RECIPE_H) {
                     final ItemStack stack;
                     if (this.menu.outputInventorySlot.hasItem())
                     {
@@ -190,17 +192,17 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
         final List<ResourceLocation> groups = new ArrayList<>(ModBlocks.getInstance().getOrComputeItemGroups().keySet());
         for(int i = this.typeIndexOffset; i < this.typeIndexOffset + 10 && i < groups.size(); ++i) {
             int drawIndex = i - this.typeIndexOffset;
-            int drawLeft = recipeAreaLeft + drawIndex % 10 * 16;
+            int drawLeft = recipeAreaLeft + drawIndex % 10 * CUTTER_RECIPE_W;
             int rowIndex = drawIndex / 10;
-            int drawTop = recipeAreaTop + rowIndex * 18 + 2;
-            int zOffset = 32;
+            int drawTop = recipeAreaTop + rowIndex * CUTTER_RECIPE_H + 2;
+            int zOffset = CUTTER_RECIPE_U_NORMAL;
             if (this.menu.getCurrentGroup() != null && i == groups.indexOf(this.menu.getCurrentGroup())) {
-                zOffset = 0;
-            } else if (x >= drawLeft && y >= drawTop && x < drawLeft + 16 && y < drawTop + 18) {
-                zOffset = 16;
+                zOffset = CUTTER_RECIPE_U_SELECTED;
+            } else if (x >= drawLeft && y >= drawTop && x < drawLeft + CUTTER_RECIPE_W && y < drawTop + CUTTER_RECIPE_H) {
+                zOffset = CUTTER_RECIPE_U_HOVERED;
             }
 
-            graphics.blit(BACKGROUND_TEXTURE1, drawLeft, drawTop - 1, zOffset, this.imageHeight, 16, 18);
+            graphics.blit(BACKGROUND_TEXTURE1, drawLeft, drawTop - 1, zOffset, CUTTER_RECIPE_V, CUTTER_RECIPE_W, CUTTER_RECIPE_H);
         }
 
         if (this.menu.getCurrentGroup() != null)
@@ -209,17 +211,17 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
             for (int i = this.recipeIndexOffset; i < recipeIndexOffset + 10 && i < list.size(); ++i)
             {
                 int drawIndex = i - this.recipeIndexOffset;
-                int drawLeft = recipeAreaLeft + drawIndex % 10 * 16;
+                int drawLeft = recipeAreaLeft + drawIndex % 10 * CUTTER_RECIPE_W;
                 int rowIndex = drawIndex / 10;
-                int drawTop = recipeAreaTop + 23 + rowIndex * 18 + 2;
-                int zOffset = 32;
+                int drawTop = recipeAreaTop + CUTTER_RECIPE_SPACING + rowIndex * CUTTER_RECIPE_H + 2;
+                int zOffset = CUTTER_RECIPE_U_NORMAL;
                 if (this.menu.getCurrentVariant() != null && i == list.indexOf(this.menu.getCurrentVariant())) {
-                    zOffset = 0;
-                } else if (x >= drawLeft && y >= drawTop && x < drawLeft + 16 && y < drawTop + 18) {
-                    zOffset = 16;
+                    zOffset = CUTTER_RECIPE_U_SELECTED;
+                } else if (x >= drawLeft && y >= drawTop && x < drawLeft + CUTTER_RECIPE_W && y < drawTop + CUTTER_RECIPE_H) {
+                    zOffset = CUTTER_RECIPE_U_HOVERED;
                 }
 
-                graphics.blit(BACKGROUND_TEXTURE1, drawLeft, drawTop - 1, zOffset, this.imageHeight, 16, 18);
+                graphics.blit(BACKGROUND_TEXTURE1, drawLeft, drawTop - 1, zOffset, CUTTER_RECIPE_V, CUTTER_RECIPE_W, CUTTER_RECIPE_H);
             }
         }
     }
@@ -228,8 +230,6 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
     {
         if (this.menu.getCurrentVariant() != null && this.menu.getCurrentVariant().getItem() instanceof BlockItem item && item.getBlock() instanceof IMateriallyTexturedBlock block)
         {
-            final int sourceLeft = 16 * 3;
-            final int sourceTop = 202;
             final int numComponents = block.getComponents().size();
             final List<ResourceLocation> input = new ArrayList<>();
             if (item instanceof IDoItem doItem)
@@ -239,13 +239,13 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
 
             for (int i = 0; i < 2; i++)
             {
-                int drawLeft = 95 + this.leftPos;
-                int drawTop = this.topPos + 65 + i * 20;
+                int drawLeft = CUTTER_INPUT_X - 1 + this.leftPos;
+                int drawTop = this.topPos + CUTTER_INPUT_Y - 1 + i * CUTTER_INPUT_SPACING;
                 if (i < input.size())
                 {
                     graphics.drawString(this.font, Component.translatable(input.get(i).getNamespace() + ".desc." + input.get(i).getPath(), Component.translatable(Constants.MOD_ID + ".desc.material", "")), drawLeft - 88, drawTop + 5, 4210752, false);
                 }
-                graphics.blit(BACKGROUND_TEXTURE1, drawLeft, drawTop, sourceLeft + (i >= numComponents ? 18 : 0), sourceTop, 18, 18);
+                graphics.blit(BACKGROUND_TEXTURE1, drawLeft, drawTop, CUTTER_SLOT_U + (i >= numComponents ? CUTTER_SLOT_W : 0), CUTTER_SLOT_V, CUTTER_SLOT_W, CUTTER_SLOT_H);
             }
         }
     }
@@ -255,9 +255,9 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
         final List<ResourceLocation> typeList = new ArrayList<>(ModBlocks.getInstance().getOrComputeItemGroups().keySet());
         for(int i = this.typeIndexOffset; i < this.typeIndexOffset + 10 && i < typeList.size(); ++i) {
             int j = i - this.typeIndexOffset;
-            int k = left + j % 10 * 16;
+            int k = left + j % 10 * CUTTER_RECIPE_W;
             int l = j / 10;
-            int i1 = top + l * 18 + 2;
+            int i1 = top + l * CUTTER_RECIPE_H + 2;
 
             graphics.renderItem(ModBlocks.getInstance().getOrComputeItemGroups().get(typeList.get(i)).get(0), k, i1);
         }
@@ -268,9 +268,9 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
             for (int i = this.recipeIndexOffset; i < this.recipeIndexOffset + 10 && i < list.size(); ++i)
             {
                 int j = i - this.recipeIndexOffset;
-                int k = left + j % 10 * 16;
+                int k = left + j % 10 * CUTTER_RECIPE_W;
                 int l = j / 10;
-                int i1 = top + 23 + l * 18 + 2;
+                int i1 = top + CUTTER_RECIPE_SPACING + l * CUTTER_RECIPE_H + 2;
 
                 if (this.menu.outputInventorySlot.hasItem())
                 {
@@ -323,15 +323,15 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
         this.clickedOnTypeScroll = false;
 
         if (this.menu.getCurrentGroup() != null) {
-            int leftOffset = this.leftPos + 58;
-            int topOffset = this.topPos + 16 + 23;
+            int leftOffset = this.leftPos + CUTTER_RECIPE_X + 1;
+            int topOffset = this.topPos + CUTTER_RECIPE_Y + CUTTER_RECIPE_SPACING;
             int scrollOffset = this.recipeIndexOffset + 10;
 
             for(int index = this.recipeIndexOffset; index < scrollOffset; ++index) {
                 int rowIndex = index - this.recipeIndexOffset;
-                double mouseXOffset = mouseX - (double)(leftOffset + rowIndex % 10 * 16);
-                double mouseYOffset = mouseY - (double)(topOffset + rowIndex / 10 * 18);
-                if (mouseXOffset >= 0.0D && mouseYOffset >= 0.0D && mouseXOffset < 16.0D && mouseYOffset < 18.0D && (this.menu).clickMenuButton(Objects.requireNonNull(Objects.requireNonNull(this.minecraft).player), index + ModBlocks.getInstance().itemGroups.size())) {
+                double mouseXOffset = mouseX - (double)(leftOffset + rowIndex % 10 * CUTTER_RECIPE_W);
+                double mouseYOffset = mouseY - (double)(topOffset + rowIndex / 10 * CUTTER_RECIPE_H);
+                if (mouseXOffset >= 0.0D && mouseYOffset >= 0.0D && mouseXOffset < CUTTER_RECIPE_W && mouseYOffset < CUTTER_RECIPE_H && (this.menu).clickMenuButton(Objects.requireNonNull(Objects.requireNonNull(this.minecraft).player), index + ModBlocks.getInstance().itemGroups.size())) {
                     Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_STONECUTTER_SELECT_RECIPE, 1.0F));
                     Objects.requireNonNull(this.minecraft.gameMode).handleInventoryButtonClick(this.menu.containerId, index + ModBlocks.getInstance().itemGroups.size());
                     variantIndexCache = index + ModBlocks.getInstance().itemGroups.size();
@@ -339,23 +339,23 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
                 }
             }
 
-            leftOffset = this.leftPos + 220;
-            if (mouseX >= (double)leftOffset && mouseX < (double)(leftOffset + 12) && mouseY >= (double)topOffset && mouseY < (double)(topOffset + 18)) {
+            leftOffset = this.leftPos + CUTTER_SLIDER_X;
+            if (mouseX >= (double)leftOffset && mouseX < (double)(leftOffset + CUTTER_SLIDER_W) && mouseY >= (double)topOffset && mouseY < (double)(topOffset + CUTTER_RECIPE_H)) {
                 this.clickedOnRecipeScroll = true;
             }
         }
 
         if (!clickedOnRecipeScroll)
         {
-            int leftOffset = this.leftPos + 58;
-            int topOffset = this.topPos + 16;
+            int leftOffset = this.leftPos + CUTTER_RECIPE_X + 1;
+            int topOffset = this.topPos + CUTTER_RECIPE_Y;
             int scrollOffset = this.typeIndexOffset + 10;
 
             for(int index = this.typeIndexOffset; index < scrollOffset; ++index) {
                 int rowIndex = index - this.typeIndexOffset;
-                double mouseXOffset = mouseX - (double)(leftOffset + rowIndex % 10 * 16);
-                double mouseYOffset = mouseY - (double)(topOffset + rowIndex / 10 * 18);
-                if (mouseXOffset >= 0.0D && mouseYOffset >= 0.0D && mouseXOffset < 16.0D && mouseYOffset < 18.0D && (this.menu).clickMenuButton(Objects.requireNonNull(Objects.requireNonNull(this.minecraft).player), index)) {
+                double mouseXOffset = mouseX - (double)(leftOffset + rowIndex % 10 * CUTTER_RECIPE_W);
+                double mouseYOffset = mouseY - (double)(topOffset + rowIndex / 10 * CUTTER_RECIPE_H);
+                if (mouseXOffset >= 0.0D && mouseYOffset >= 0.0D && mouseXOffset < CUTTER_RECIPE_W && mouseYOffset < CUTTER_RECIPE_H && (this.menu).clickMenuButton(Objects.requireNonNull(Objects.requireNonNull(this.minecraft).player), index)) {
                     Minecraft.getInstance().getSoundManager().play(SimpleSoundInstance.forUI(SoundEvents.UI_STONECUTTER_SELECT_RECIPE, 1.0F));
                     Objects.requireNonNull(this.minecraft.gameMode).handleInventoryButtonClick(this.menu.containerId, index);
                     groupIndexCache = index;
@@ -365,8 +365,8 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
                 }
             }
 
-            leftOffset = this.leftPos + 220;
-            if (mouseX >= (double)leftOffset && mouseX < (double)(leftOffset + 12) && mouseY >= (double)topOffset && mouseY < (double)(topOffset + 18)) {
+            leftOffset = this.leftPos + CUTTER_SLIDER_X;
+            if (mouseX >= (double)leftOffset && mouseX < (double)(leftOffset + CUTTER_SLIDER_W) && mouseY >= (double)topOffset && mouseY < (double)(topOffset + CUTTER_RECIPE_H)) {
                 this.clickedOnTypeScroll = true;
             }
         }
@@ -377,7 +377,7 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
     @Override
     public boolean mouseDragged(double mouseX, double mouseY, int button, double dragX, double dragY) {
         if (this.clickedOnRecipeScroll && this.canScrollRecipes()) {
-            int i = this.topPos + 16 + 23;
+            int i = this.topPos + CUTTER_RECIPE_Y + CUTTER_RECIPE_SPACING;
             int j = i + 10;
             this.recipeSliderProgress = ((float)mouseY - (float)i - 7.5F) / ((float)(j - i) - 5.0F);
             this.recipeSliderProgress = Mth.clamp(this.recipeSliderProgress, 0.0F, 1.0F);
@@ -385,7 +385,7 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
             return true;
         }
         else if (this.clickedOnTypeScroll && this.canScrollTypes()) {
-            int i = this.topPos + 16;
+            int i = this.topPos + CUTTER_RECIPE_Y;
             int j = i + 10;
             this.typeSliderProgress = ((float)mouseY - (float)i - 7.5F) / ((float)(j - i) - 5.0F);
             this.typeSliderProgress = Mth.clamp(this.typeSliderProgress, 0.0F, 1.0F);
@@ -400,12 +400,12 @@ public class ArchitectsCutterScreen extends AbstractContainerScreen<ArchitectsCu
     public boolean mouseScrolled(double mouseX, double mouseY, double delta) {
 
         boolean onlyTypes = false;
-        if (mouseX >= this.leftPos + 55 && mouseY >= this.topPos + 15 && mouseX < this.leftPos + 220 && mouseY < this.topPos + 35) {
+        if (mouseX >= this.leftPos + 55 && mouseY >= this.topPos + 15 && mouseX < this.leftPos + CUTTER_SLIDER_X && mouseY < this.topPos + 35) {
             onlyTypes = true;
         }
 
         boolean onlyRecipes = false;
-        if (mouseX >= this.leftPos + 55 && mouseY >= this.topPos + 40 && mouseX < this.leftPos + 220 && mouseY < this.topPos + 60) {
+        if (mouseX >= this.leftPos + 55 && mouseY >= this.topPos + 40 && mouseX < this.leftPos + CUTTER_SLIDER_X && mouseY < this.topPos + 60) {
             onlyRecipes = true;
         }
 

--- a/src/main/java/com/ldtteam/domumornamentum/container/ArchitectsCutterContainer.java
+++ b/src/main/java/com/ldtteam/domumornamentum/container/ArchitectsCutterContainer.java
@@ -23,6 +23,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static com.ldtteam.domumornamentum.util.GuiConstants.*;
+
 public class ArchitectsCutterContainer extends AbstractContainerMenu
 {
     /**
@@ -103,8 +105,8 @@ public class ArchitectsCutterContainer extends AbstractContainerMenu
         this.world = playerInventoryIn.player.level();
         for (int i = 0; i < MateriallyTexturedBlockManager.getInstance().getMaxTexturableComponentCount(); i++)
         {
-            int x = 96;
-            int y = 66 + i * 20;;
+            int x = CUTTER_INPUT_X;
+            int y = CUTTER_INPUT_Y + i * CUTTER_INPUT_SPACING;
             this.inputInventorySlots.add(
               this.addSlot(new Slot(this.inputInventory, i, x, y) {
                   @Override
@@ -123,7 +125,7 @@ public class ArchitectsCutterContainer extends AbstractContainerMenu
             );
         }
 
-        this.outputInventorySlot = this.addSlot(new Slot(this.inventory, 1, 183, 77) {
+        this.outputInventorySlot = this.addSlot(new Slot(this.inventory, 1, CUTTER_OUTPUT_X, CUTTER_OUTPUT_Y) {
             public boolean mayPlace(@NotNull ItemStack stack) {
                 return false;
             }

--- a/src/main/java/com/ldtteam/domumornamentum/event/handlers/ModBusEventHandler.java
+++ b/src/main/java/com/ldtteam/domumornamentum/event/handlers/ModBusEventHandler.java
@@ -1,5 +1,6 @@
 package com.ldtteam.domumornamentum.event.handlers;
 
+import com.ldtteam.domumornamentum.Network;
 import com.ldtteam.domumornamentum.datagen.allbrick.AllBrickBlockStateProvider;
 import com.ldtteam.domumornamentum.datagen.allbrick.AllBrickBlockTagProvider;
 import com.ldtteam.domumornamentum.datagen.bricks.BrickBlockStateProvider;
@@ -64,10 +65,21 @@ import com.ldtteam.domumornamentum.util.Constants;
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 
 @Mod.EventBusSubscriber(modid = Constants.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class ModBusEventHandler
 {
+    /**
+     * Called when mod is being initialized.
+     *
+     * @param event event
+     */
+    @SubscribeEvent
+    public static void onModInit(final FMLCommonSetupEvent event)
+    {
+        Network.getNetwork().registerMessages();
+    }
 
     @SubscribeEvent
     public static void dataGeneratorSetup(final GatherDataEvent event)

--- a/src/main/java/com/ldtteam/domumornamentum/jei/ArchitectsCutterGuiHandler.java
+++ b/src/main/java/com/ldtteam/domumornamentum/jei/ArchitectsCutterGuiHandler.java
@@ -1,0 +1,73 @@
+package com.ldtteam.domumornamentum.jei;
+
+import com.ldtteam.domumornamentum.Network;
+import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
+import com.ldtteam.domumornamentum.client.screens.ArchitectsCutterScreen;
+import com.ldtteam.domumornamentum.network.messages.CreativeSetArchitectCutterSlotMessage;
+import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * JEI GUI handler for the {@link ArchitectsCutterScreen}.
+ */
+public class ArchitectsCutterGuiHandler implements IGhostIngredientHandler<ArchitectsCutterScreen>
+{
+    @NotNull
+    @Override
+    public <I> List<Target<I>> getTargetsTyped(@NotNull final ArchitectsCutterScreen gui,
+                                               @NotNull final ITypedIngredient<I> ingredient,
+                                               final boolean doStart)
+    {
+        final List<Target<I>> targets = new ArrayList<>();
+        final LocalPlayer player = Minecraft.getInstance().player;
+        if (player != null && player.isCreative())
+        {
+            ingredient.getItemStack().ifPresent(stack ->
+            {
+                if (gui.getMenu().getCurrentVariant() != null &&
+                        gui.getMenu().getCurrentVariant().getItem() instanceof BlockItem item &&
+                        item.getBlock() instanceof IMateriallyTexturedBlock block)
+                {
+                    for (int i = 0; i < block.getComponents().size(); ++i)
+                    {
+                        final Slot slot = gui.getMenu().slots.get(i);
+                        if (slot.isActive() && slot.mayPlace(stack))
+                        {
+                            targets.add(new Target<>()
+                            {
+                                @NotNull
+                                @Override
+                                public Rect2i getArea()
+                                {
+                                    return new Rect2i(gui.getGuiLeft() + slot.x, gui.getGuiTop() + slot.y, 17, 17);
+                                }
+
+                                @Override
+                                public void accept(@NotNull final I ingredient)
+                                {
+                                    Network.getNetwork().sendToServer(new CreativeSetArchitectCutterSlotMessage(slot.index, (ItemStack) ingredient));
+                                }
+                            });
+                        }
+                    }
+                }
+            });
+        }
+        return targets;
+    }
+
+    @Override
+    public void onComplete()
+    {
+    }
+}

--- a/src/main/java/com/ldtteam/domumornamentum/jei/JEIPlugin.java
+++ b/src/main/java/com/ldtteam/domumornamentum/jei/JEIPlugin.java
@@ -1,6 +1,7 @@
 package com.ldtteam.domumornamentum.jei;
 import com.ldtteam.domumornamentum.IDomumOrnamentumApi;
 import com.ldtteam.domumornamentum.block.IModBlocks;
+import com.ldtteam.domumornamentum.client.screens.ArchitectsCutterScreen;
 import com.ldtteam.domumornamentum.recipe.ModRecipeSerializers;
 import com.ldtteam.domumornamentum.recipe.ModRecipeTypes;
 import mezz.jei.api.IModPlugin;
@@ -70,6 +71,12 @@ public class JEIPlugin implements IModPlugin
         registration.addRecipeCatalyst(VanillaTypes.ITEM_STACK,
                 new ItemStack(IDomumOrnamentumApi.getInstance().getBlocks().getArchitectsCutter()),
                 ArchitectsCutterCategory.TYPE);
+    }
+
+    @Override
+    public void registerGuiHandlers(@NotNull final IGuiHandlerRegistration registration)
+    {
+        registration.addGhostIngredientHandler(ArchitectsCutterScreen.class, new ArchitectsCutterGuiHandler());
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/network/NetworkChannel.java
+++ b/src/main/java/com/ldtteam/domumornamentum/network/NetworkChannel.java
@@ -1,0 +1,97 @@
+package com.ldtteam.domumornamentum.network;
+
+import com.ldtteam.domumornamentum.network.messages.IMessage;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.network.NetworkRegistry;
+import net.minecraftforge.network.PacketDistributor;
+import net.minecraftforge.network.simple.SimpleChannel;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static com.ldtteam.domumornamentum.util.Constants.MOD_ID;
+
+/**
+ * Simple network channel.
+ */
+public class NetworkChannel
+{
+    /**
+     * Forge network channel
+     */
+    private final SimpleChannel rawChannel;
+
+    /**
+     * Creates a new instance of network channel.
+     *
+     * @param channelName unique channel name
+     * @throws IllegalArgumentException if channelName already exists
+     */
+    public NetworkChannel(final String channelName)
+    {
+        final String modVersion = ModList.get().getModContainerById(MOD_ID).get().getModInfo().getVersion().toString();
+        rawChannel = NetworkRegistry.newSimpleChannel(new ResourceLocation(MOD_ID, channelName), () -> modVersion, str -> str.equals(modVersion), str -> str.equals(modVersion));
+    }
+
+    public void registerMessages()
+    {
+        int idx = 0;
+
+    }
+
+    /**
+     * Register a message into rawChannel.
+     *
+     * @param <MSG>      message class type
+     * @param id         network id
+     * @param msgClazz   message class
+     * @param msgCreator supplier with new instance of msgClazz
+     */
+    private <MSG extends IMessage> void registerMessage(final int id, final Class<MSG> msgClazz, final Function<FriendlyByteBuf, MSG> msgCreator)
+    {
+        rawChannel.registerMessage(id, msgClazz, IMessage::toBytes, msgCreator, NetworkChannel::execute);
+    }
+
+    /**
+     * Execute the received message.
+     *
+     * @param msg         the message.
+     * @param ctxSupplier the context supplier.
+     */
+    private static void execute(@NotNull final IMessage msg, @NotNull final Supplier<NetworkEvent.Context> ctxSupplier)
+    {
+        final NetworkEvent.Context ctx = ctxSupplier.get();
+        final LogicalSide packetOrigin = ctx.getDirection().getOriginationSide();
+        if (msg.getExecutionSide() == null || !packetOrigin.equals(msg.getExecutionSide()))
+        {
+            ctx.enqueueWork(() -> msg.onExecute(ctx, packetOrigin.equals(LogicalSide.CLIENT)));
+        }
+    }
+
+    /**
+     * Sends to server.
+     *
+     * @param msg message to send
+     */
+    public void sendToServer(final IMessage msg)
+    {
+        rawChannel.sendToServer(msg);
+    }
+
+    /**
+     * Sends to player.
+     *
+     * @param msg    message to send
+     * @param player target player
+     */
+    public void sendToPlayer(final IMessage msg, final ServerPlayer player)
+    {
+        rawChannel.send(PacketDistributor.PLAYER.with(() -> player), msg);
+    }
+}

--- a/src/main/java/com/ldtteam/domumornamentum/network/NetworkChannel.java
+++ b/src/main/java/com/ldtteam/domumornamentum/network/NetworkChannel.java
@@ -1,5 +1,6 @@
 package com.ldtteam.domumornamentum.network;
 
+import com.ldtteam.domumornamentum.network.messages.CreativeSetArchitectCutterSlotMessage;
 import com.ldtteam.domumornamentum.network.messages.IMessage;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
@@ -43,6 +44,7 @@ public class NetworkChannel
     {
         int idx = 0;
 
+        registerMessage(++idx, CreativeSetArchitectCutterSlotMessage.class, CreativeSetArchitectCutterSlotMessage::new);
     }
 
     /**

--- a/src/main/java/com/ldtteam/domumornamentum/network/messages/CreativeSetArchitectCutterSlotMessage.java
+++ b/src/main/java/com/ldtteam/domumornamentum/network/messages/CreativeSetArchitectCutterSlotMessage.java
@@ -1,0 +1,74 @@
+package com.ldtteam.domumornamentum.network.messages;
+
+import com.ldtteam.domumornamentum.client.screens.ArchitectsCutterScreen;
+import com.ldtteam.domumornamentum.container.ArchitectsCutterContainer;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.network.NetworkEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Sets the item in the {@link ArchitectsCutterScreen} for creative mode.
+ */
+public class CreativeSetArchitectCutterSlotMessage implements IMessage
+{
+    private final int slot;
+    private final ItemStack stack;
+
+    /**
+     * Construct message.
+     * @param slot  the slot index to set.
+     * @param stack the item stack to set.
+     */
+    public CreativeSetArchitectCutterSlotMessage(final int slot, @NotNull final ItemStack stack)
+    {
+        this.slot = slot;
+        this.stack = stack;
+    }
+
+    /**
+     * Construct from network.
+     * @param buf the buffer.
+     */
+    public CreativeSetArchitectCutterSlotMessage(@NotNull final FriendlyByteBuf buf)
+    {
+        this.slot = buf.readVarInt();
+        this.stack = buf.readItem();
+    }
+
+    @Override
+    public void toBytes(@NotNull final FriendlyByteBuf buf)
+    {
+        buf.writeVarInt(this.slot);
+        buf.writeItem(this.stack);
+    }
+
+    @Nullable
+    @Override
+    public LogicalSide getExecutionSide()
+    {
+        return LogicalSide.SERVER;
+    }
+
+    @Override
+    public void onExecute(@NotNull final NetworkEvent.Context ctxIn, final boolean isLogicalServer)
+    {
+        final ServerPlayer player = ctxIn.getSender();
+
+        if (player != null && player.isCreative() && player.containerMenu instanceof ArchitectsCutterContainer menu)
+        {
+            if (this.slot >= 0 && this.slot < menu.slots.size())
+            {
+                final Slot menuSlot = menu.slots.get(this.slot);
+                if (menuSlot.isActive() && menuSlot.allowModification(player) && menuSlot.mayPlace(this.stack))
+                {
+                    menuSlot.setByPlayer(this.stack);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/ldtteam/domumornamentum/network/messages/IMessage.java
+++ b/src/main/java/com/ldtteam/domumornamentum/network/messages/IMessage.java
@@ -1,0 +1,36 @@
+package com.ldtteam.domumornamentum.network.messages;
+
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.network.NetworkEvent;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Interface for all network messages
+ */
+public interface IMessage
+{
+    /**
+     * Writes message data to buffer.
+     *
+     * @param buf network data byte buffer
+     */
+    void toBytes(final FriendlyByteBuf buf);
+
+    /**
+     * Which sides is message able to be executed at.
+     *
+     * @return CLIENT or SERVER or null (for both)
+     */
+    @Nullable
+    LogicalSide getExecutionSide();
+
+    /**
+     * Executes message action.
+     *
+     * @param ctxIn           network context of incoming message
+     * @param isLogicalServer whether message arrived at logical server side
+     */
+    void onExecute(final NetworkEvent.Context ctxIn, final boolean isLogicalServer);
+}

--- a/src/main/java/com/ldtteam/domumornamentum/util/GuiConstants.java
+++ b/src/main/java/com/ldtteam/domumornamentum/util/GuiConstants.java
@@ -1,0 +1,55 @@
+package com.ldtteam.domumornamentum.util;
+
+/**
+ * Magic numbers for the GUI.
+ */
+public class GuiConstants
+{
+    // Main background texture
+    public static final int CUTTER_BG_W = 242;
+    public static final int CUTTER_BG_H = 202;
+
+    // Input slots
+    public static final int CUTTER_INPUT_X = 96;
+    public static final int CUTTER_INPUT_Y = 66;
+    public static final int CUTTER_INPUT_SPACING = 20;
+
+    // Output slots
+    public static final int CUTTER_OUTPUT_X = 183;
+    public static final int CUTTER_OUTPUT_Y = 77;
+
+    // Slot texture
+    public static final int CUTTER_SLOT_U = 16 * 3;
+    public static final int CUTTER_SLOT_V = CUTTER_BG_H;
+    public static final int CUTTER_SLOT_W = 18;
+    public static final int CUTTER_SLOT_H = 18;
+
+    // Recipe selector buttons
+    public static final int CUTTER_RECIPE_X = 8 + 49;
+    public static final int CUTTER_RECIPE_Y = 16;
+    public static final int CUTTER_RECIPE_SPACING = 23;
+
+    // Recipe selector button textures
+    public static final int CUTTER_RECIPE_U_SELECTED = 0;
+    public static final int CUTTER_RECIPE_U_HOVERED = 16;
+    public static final int CUTTER_RECIPE_U_NORMAL = 32;
+    public static final int CUTTER_RECIPE_V = CUTTER_BG_H;
+    public static final int CUTTER_RECIPE_W = 16;
+    public static final int CUTTER_RECIPE_H = 18;
+
+    // Scroll slider location
+    public static final int CUTTER_SLIDER_X = 220;
+    public static final int CUTTER_SLIDER_Y = CUTTER_RECIPE_Y + 1;
+
+    // Scroll slider texture
+    public static final int CUTTER_SLIDER_U_ENABLED = 0;
+    public static final int CUTTER_SLIDER_U_DISABLED = 12;
+    public static final int CUTTER_SLIDER_V = 220;
+    public static final int CUTTER_SLIDER_W = 12;
+    public static final int CUTTER_SLIDER_H = 15;
+
+    private GuiConstants()
+    {
+        // do not construct
+    }
+}


### PR DESCRIPTION
* Includes JEI when running in DO-only dev environment, for debug/test purposes (and hopefully reduce the chance of breaking it in the future).
* Adds support (in creative mode only) to drag blocks directly from JEI to the Architect's Cutter input slots.
    * These are real blocks and can be pulled back out into the player's inventory, hence being creative-only.
* Adds simple networking channel (does not implement message splitting, but it's not needed since it's only for a very small message at present).
* Fixes JEI display after the new GUI changes, and extracts several magic constants from both to try to keep them closer in sync in future.
    * This also fixes an incorrect display of the scrollbar thumb in the actual cutter GUI that was apparently overlooked.
    * There might be some additional places where constants should be used that I've overlooked where the relationship of derived constants was not apparent.

![image](https://github.com/ldtteam/Domum-Ornamentum/assets/539951/93e7a475-2e87-45bc-9a8c-384ac36de0e4)

Possibly also of note is that I could not get DO to build until I switched OPC from `FG6` to `main`; I have not included that change here.

Only tested in 1.20 but should be backportable (only if the new cutter GUI has been backported).