### PR TITLE
Avoid crash in cutter when no items

### DIFF
--- a/src/main/java/com/ldtteam/domumornamentum/block/ModBlocks.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/ModBlocks.java
@@ -300,10 +300,12 @@ public final class ModBlocks implements IModBlocks {
         if (itemGroups.isEmpty())
         {
             ForgeRegistries.ITEMS.forEach(item -> {
-                if (item instanceof IDoItem)
+                if (item instanceof IDoItem doItem)
                 {
-                    final List<ItemStack> itemList = itemGroups.getOrDefault(((IDoItem) item).getGroup(), new ArrayList<>());
-                    if (item instanceof BlockItem blockitem && blockitem.getBlock() instanceof IMateriallyTexturedBlock texturedBlock) {
+                    final List<ItemStack> itemList = itemGroups.getOrDefault(doItem.getGroup(), new ArrayList<>());
+
+                    if (item instanceof BlockItem blockitem && blockitem.getBlock() instanceof IMateriallyTexturedBlock texturedBlock)
+                    {
                         if (blockitem.getBlock() instanceof ICachedItemGroupBlock cachedItemGroupBlock)
                         {
                             final NonNullList<ItemStack> stacks = NonNullList.create();
@@ -319,7 +321,11 @@ public final class ModBlocks implements IModBlocks {
                             itemList.add(process(new ItemStack(item), texturedBlock));
                         }
                     }
-                    itemGroups.put(((IDoItem) item).getGroup(), itemList);
+
+                    if (!itemList.isEmpty())
+                    {
+                        itemGroups.put(doItem.getGroup(), itemList);
+                    }
                 }
             });
         }


### PR DESCRIPTION
Fixes [discord report](https://discord.com/channels/139070364159311872/1125094832143077456/1168249570564784241) ([log](https://gist.github.com/fshiruba/4325f763b06c5c172d6062dc7aad3593))

This is one of those "it should never happen" things, and yet it did.  The crash occurred because there was a cutter group that contained no items, likely due to some other mod doing something dodgy to the recipe or tag lists.  (There are mods that can deliberately remove or disable recipes, though I assume this was not intentional here.)

This change is just a paranoia check to avoid creating empty groups in the case that the recipe removal was actually intentional.  I have not tested that particular case (since idk how it happened).  It's likely that a similar problem might happen if all groups are removed as a result, but in that case you probably deserve the crash since the cutter has no purpose any more.

Also includes some minor tidy-up of nearby code; the `isEmpty` check at the bottom is the actual fix.