### PR TITLE
Add back missing texture mappings on shingles

### DIFF
--- a/src/main/resources/assets/domum_ornamentum/models/block/shingle/flat_concave_spec.json
+++ b/src/main/resources/assets/domum_ornamentum/models/block/shingle/flat_concave_spec.json
@@ -3,6 +3,7 @@
 	"ambientocclusion": false,
 	"textures": {
 		"1": "block/clay",
+        "plank": "block/oak_planks",
 		"particle": "block/clay",
 		"1_plank": "block/oak_planks"
 	},

--- a/src/main/resources/assets/domum_ornamentum/models/block/shingle/flat_concave_spec.json
+++ b/src/main/resources/assets/domum_ornamentum/models/block/shingle/flat_concave_spec.json
@@ -1,12 +1,12 @@
 {
 	"credit": "Made with Blockbench",
 	"ambientocclusion": false,
-    "textures": {
-        "1": "block/clay",
-        "plank": "block/oak_planks",
-        "particle": "block/clay",
-        "1_plank": "block/oak_planks"
-    },
+	"textures": {
+		"1": "block/clay",
+		"plank": "block/oak_planks",
+		"particle": "block/clay",
+		"1_plank": "block/oak_planks"
+	},
 	"elements": [
 		{
 			"name": "support_panel_D",

--- a/src/main/resources/assets/domum_ornamentum/models/block/shingle/flat_concave_spec.json
+++ b/src/main/resources/assets/domum_ornamentum/models/block/shingle/flat_concave_spec.json
@@ -1,12 +1,12 @@
 {
 	"credit": "Made with Blockbench",
 	"ambientocclusion": false,
-	"textures": {
-		"1": "block/clay",
+    "textures": {
+        "1": "block/clay",
         "plank": "block/oak_planks",
-		"particle": "block/clay",
-		"1_plank": "block/oak_planks"
-	},
+        "particle": "block/clay",
+        "1_plank": "block/oak_planks"
+    },
 	"elements": [
 		{
 			"name": "support_panel_D",

--- a/src/main/resources/assets/domum_ornamentum/models/block/shingle/flat_lower_concave_spec.json
+++ b/src/main/resources/assets/domum_ornamentum/models/block/shingle/flat_lower_concave_spec.json
@@ -2,6 +2,8 @@
 	"credit": "Made with Blockbench",
 	"ambientocclusion": false,
 	"textures": {
+        "1": "block/clay",
+        "plank": "block/oak_planks",
 		"1_plank": "block/oak_planks",
 		"particle": "block/clay",
 		"2_1": "block/clay"

--- a/src/main/resources/assets/domum_ornamentum/models/block/shingle/flat_lower_concave_spec.json
+++ b/src/main/resources/assets/domum_ornamentum/models/block/shingle/flat_lower_concave_spec.json
@@ -2,8 +2,8 @@
 	"credit": "Made with Blockbench",
 	"ambientocclusion": false,
 	"textures": {
-        "1": "block/clay",
-        "plank": "block/oak_planks",
+		"1": "block/clay",
+		"plank": "block/oak_planks",
 		"1_plank": "block/oak_planks",
 		"particle": "block/clay",
 		"2_1": "block/clay"


### PR DESCRIPTION
Re-add a few of the accidently removed shingle texture mappings caused some of the faces to turn purple.

Fixes #248 