### PR TITLE
(Version/1.21) Adding 4 outer corner post models to satisfy desired corner panel requests.

### DIFF
--- a/src/main/resources/assets/domum_ornamentum/models/block/post/post_corner_double_spec.json
+++ b/src/main/resources/assets/domum_ornamentum/models/block/post/post_corner_double_spec.json
@@ -1,0 +1,44 @@
+{
+	"format_version": "1.21.6",
+	"credit": "Made with Blockbench",
+	"parent": "block/block",
+	"textures": {
+		"1": "oak_planks",
+		"particle": "oak_planks"
+	},
+	"elements": [
+		{
+			"from": [0, 0, 0],
+			"to": [3, 16, 3],
+			"faces": {
+				"north": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"east": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"south": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"west": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"up": {"uv": [2.75, 2.75, 5.25, 5.25], "rotation": 270, "texture": "#1"},
+				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 90, "texture": "#1"}
+			}
+		},
+		{
+			"from": [13, 0, 0],
+			"to": [16, 16, 3],
+			"rotation": {"angle": 0, "axis": "y", "origin": [-0.5, 0, 0]},
+			"faces": {
+				"north": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"east": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"south": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"west": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"up": {"uv": [10.75, 2.75, 13.25, 5.25], "rotation": 270, "texture": "#1"},
+				"down": {"uv": [10.75, 10.75, 13.25, 13.25], "rotation": 90, "texture": "#1"}
+			}
+		}
+	],
+	"groups": [
+		{
+			"name": "VoxelShapes",
+			"origin": [8, 8, 8],
+			"color": 0,
+			"children": [0, 1]
+		}
+	]
+}

--- a/src/main/resources/assets/domum_ornamentum/models/block/post/post_corner_quad_spec.json
+++ b/src/main/resources/assets/domum_ornamentum/models/block/post/post_corner_quad_spec.json
@@ -1,0 +1,67 @@
+{
+	"format_version": "1.21.6",
+	"credit": "Made with Blockbench",
+	"parent": "block/block",
+	"textures": {
+		"1": "oak_planks",
+		"particle": "oak_planks"
+	},
+	"elements": [
+		{
+			"from": [0, 0, 13],
+			"to": [3, 16, 16],
+			"faces": {
+				"north": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"east": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"south": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"west": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"up": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 270, "texture": "#1"},
+				"down": {"uv": [2.75, 2.75, 5.25, 5.25], "rotation": 90, "texture": "#1"}
+			}
+		},
+		{
+			"from": [0, 0, 0],
+			"to": [3, 16, 3],
+			"faces": {
+				"north": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"east": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"south": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"west": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"up": {"uv": [2.75, 2.75, 5.25, 5.25], "rotation": 270, "texture": "#1"},
+				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 90, "texture": "#1"}
+			}
+		},
+		{
+			"from": [13, 0, 13],
+			"to": [16, 16, 16],
+			"faces": {
+				"north": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"east": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"south": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"west": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"up": {"uv": [10.75, 10.75, 13.25, 13.25], "rotation": 270, "texture": "#1"},
+				"down": {"uv": [10.75, 2.75, 13.25, 5.25], "rotation": 90, "texture": "#1"}
+			}
+		},
+		{
+			"from": [13, 0, 0],
+			"to": [16, 16, 3],
+			"faces": {
+				"north": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"east": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"south": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"west": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"up": {"uv": [10.75, 2.75, 13.25, 5.25], "rotation": 270, "texture": "#1"},
+				"down": {"uv": [10.75, 10.75, 13.25, 13.25], "rotation": 90, "texture": "#1"}
+			}
+		}
+	],
+	"groups": [
+		{
+			"name": "VoxelShapes",
+			"origin": [8, 8, 8],
+			"color": 0,
+			"children": [0, 1, 2, 3]
+		}
+	]
+}

--- a/src/main/resources/assets/domum_ornamentum/models/block/post/post_corner_single_spec.json
+++ b/src/main/resources/assets/domum_ornamentum/models/block/post/post_corner_single_spec.json
@@ -1,0 +1,31 @@
+{
+	"format_version": "1.21.6",
+	"credit": "Made with Blockbench",
+	"parent": "block/block",
+	"textures": {
+		"1": "oak_planks",
+		"particle": "oak_planks"
+	},
+	"elements": [
+		{
+			"from": [0, 0, 0],
+			"to": [3, 16, 3],
+			"faces": {
+				"north": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"east": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"south": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"west": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"up": {"uv": [2.75, 2.75, 5.25, 5.25], "rotation": 270, "texture": "#1"},
+				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 90, "texture": "#1"}
+			}
+		}
+	],
+	"groups": [
+		{
+			"name": "VoxelShapes",
+			"origin": [8, 8, 8],
+			"color": 0,
+			"children": [0]
+		}
+	]
+}

--- a/src/main/resources/assets/domum_ornamentum/models/block/post/post_corner_triple_spec.json
+++ b/src/main/resources/assets/domum_ornamentum/models/block/post/post_corner_triple_spec.json
@@ -1,0 +1,55 @@
+{
+	"format_version": "1.21.6",
+	"credit": "Made with Blockbench",
+	"parent": "block/block",
+	"textures": {
+		"1": "oak_planks",
+		"particle": "oak_planks"
+	},
+	"elements": [
+		{
+			"from": [0, 0, 0],
+			"to": [3, 16, 3],
+			"faces": {
+				"north": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"east": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"south": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"west": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"up": {"uv": [2.75, 2.75, 5.25, 5.25], "rotation": 270, "texture": "#1"},
+				"down": {"uv": [2.75, 10.75, 5.25, 13.25], "rotation": 90, "texture": "#1"}
+			}
+		},
+		{
+			"from": [13, 0, 13],
+			"to": [16, 16, 16],
+			"faces": {
+				"north": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"east": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"south": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"west": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"up": {"uv": [10.75, 10.75, 13.25, 13.25], "rotation": 270, "texture": "#1"},
+				"down": {"uv": [10.75, 2.75, 13.25, 5.25], "rotation": 90, "texture": "#1"}
+			}
+		},
+		{
+			"from": [13, 0, 0],
+			"to": [16, 16, 3],
+			"faces": {
+				"north": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"east": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"south": {"uv": [10.75, 0, 13.25, 16], "texture": "#1"},
+				"west": {"uv": [2.75, 0, 5.25, 16], "texture": "#1"},
+				"up": {"uv": [10.75, 2.75, 13.25, 5.25], "rotation": 270, "texture": "#1"},
+				"down": {"uv": [10.75, 10.75, 13.25, 13.25], "rotation": 90, "texture": "#1"}
+			}
+		}
+	],
+	"groups": [
+		{
+			"name": "VoxelShapes",
+			"origin": [8, 8, 8],
+			"color": 0,
+			"children": [0, 1, 2]
+		}
+	]
+}


### PR DESCRIPTION
As one of the people asking for corner panel models, I understand the issue the previous suggestions create for pathing. Thank you for addressing that in the stream. While listening to you and seeing you demonstrate, I had a new thought on the matter.

Instead of panels, we add to the **post** options with flush corner models:

<img width="896" height="483" alt="image" src="https://github.com/user-attachments/assets/24fde98e-3db6-4a3e-96fb-83a5780ed297" />

What this would allow is for builders to make a corner using the outer edges instead of the inner, and to be able to fill that missing 3/16ths corner gap like so: _(Panels full in spruce, corner post in oak for visibility)_

<img width="930" height="628" alt="image" src="https://github.com/user-attachments/assets/4e5b1238-169d-4bc4-8fdd-b53514754624" />

<img width="819" height="845" alt="image" src="https://github.com/user-attachments/assets/5250964a-3b4a-45aa-ad4c-858e99b05ea6" />

This would allow for flush, smooth corners made from panels but without the tight <1 block clearance issue for pathfinding,

<img width="779" height="768" alt="image" src="https://github.com/user-attachments/assets/cbbacc01-3445-4de9-94b5-49233c9f5af7" />

It is also versatile enough to be used for other decorative items such as table/desk legs, etc.

A double, triple, and quad version, also included, offers more versatility as well whether for aforementioned decor, narrow alleyways, etc.

The model and UVs are drawn directly from the existing post_quad_spec
