### PR TITLE
Item render fix

### DIFF
--- a/src/main/java/com/ldtteam/domumornamentum/client/model/baked/MateriallyTexturedBakedModel.java
+++ b/src/main/java/com/ldtteam/domumornamentum/client/model/baked/MateriallyTexturedBakedModel.java
@@ -77,14 +77,8 @@ public class MateriallyTexturedBakedModel implements BakedModel {
             return ChunkRenderTypeSet.none();
         }
 
-        return ChunkRenderTypeSet.union(
-                Stream.concat(
-                        textureData.getTexturedComponents().values().stream()
-                                .map(block -> Minecraft.getInstance().getBlockRenderer().getBlockModel(block.defaultBlockState())
-                                        .getRenderTypes(block.defaultBlockState(), rand, ModelData.EMPTY)),
-                        Stream.of(SOLID_ONLY))
-                .toArray(ChunkRenderTypeSet[]::new)
-        );
+        // Delegate to the shared helper.
+        return computeRenderTypesForMaterials(textureData, rand);
     }
 
     @Override
@@ -158,7 +152,16 @@ public class MateriallyTexturedBakedModel implements BakedModel {
             return Collections.emptyList();
         }
 
-        return Lists.newArrayList(getRenderTypes(blockItem, textureData));
+        // Use the same logic as the block path: union of materials + SOLID.
+        ChunkRenderTypeSet typeSet = computeRenderTypesForMaterials(textureData, RANDOM);
+
+        List<RenderType> types = new ArrayList<>(typeSet.asList());
+        if (!types.contains(RenderType.solid())) 
+        {
+            types.add(RenderType.solid());
+        }
+
+        return types;
     }
 
     private Collection<RenderType> getRenderTypes(BlockItem blockItem, MaterialTextureData textureData) {
@@ -181,20 +184,33 @@ public class MateriallyTexturedBakedModel implements BakedModel {
             textureData = generateRandomTextureDataFrom(itemStack);
         }
 
-        Collection<RenderType> renderTypes = getRenderTypes(blockItem, textureData);
-        if (renderTypes.isEmpty()) {
+        // Update to use helper
+        ChunkRenderTypeSet typeSet = computeRenderTypesForMaterials(textureData, RANDOM);
+        List<RenderType> renderTypes = new ArrayList<>(typeSet.asList());
+
+        if (renderTypes.isEmpty()) 
+        {
             return Collections.emptyList();
         }
 
+        // Always allow a solid pass as a fallback
+        if (!renderTypes.contains(RenderType.solid())) 
+        {
+            renderTypes.add(RenderType.solid());
+        }
+
         MaterialTextureData finalTextureData = textureData;
-        final List<BakedModel> models = new ArrayList<>();
+        List<BakedModel> models = new ArrayList<>();
+
         renderTypes.stream()
-                .map(type -> getRenderType(type, fabulous))
-                .distinct()
-                .map(type -> new SpecificRenderTypeBakedModelWrapper(
-                        type,
-                        getBakedInnerModelFor(itemStack, finalTextureData, blockItem.getBlock().defaultBlockState(), type)
-                )).forEach(models::add);
+            .map(type -> getRenderType(type, fabulous))
+            .distinct()
+            .map(type -> new SpecificRenderTypeBakedModelWrapper(
+                    type,
+                    getBakedInnerModelFor(itemStack, finalTextureData, blockItem.getBlock().defaultBlockState(), type)
+            ))
+            .forEach(models::add);
+
         return models;
     }
 
@@ -281,5 +297,27 @@ public class MateriallyTexturedBakedModel implements BakedModel {
         } else {
             return Sheets.cutoutBlockSheet();
         }
+    }
+    
+    protected ChunkRenderTypeSet computeRenderTypesForMaterials(@Nullable MaterialTextureData textureData, RandomSource rand) 
+    {
+        if (textureData == null || textureData.isEmpty()) 
+        {
+            // worst case, draw as solid only
+            return SOLID_ONLY;
+        }
+
+        // For each material block: ask its baked model which RenderTypes it uses,
+        // then union all of those plus SOLID_ONLY.
+        return ChunkRenderTypeSet.union(
+            Stream.concat(
+                textureData.getTexturedComponents().values().stream()
+                    .map(block -> Minecraft.getInstance()
+                        .getBlockRenderer()
+                        .getBlockModel(block.defaultBlockState())
+                        .getRenderTypes(block.defaultBlockState(), rand, ModelData.EMPTY)),
+                Stream.of(SOLID_ONLY)
+            ).toArray(ChunkRenderTypeSet[]::new)
+        );
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/client/model/baked/MateriallyTexturedBakedModel.java
+++ b/src/main/java/com/ldtteam/domumornamentum/client/model/baked/MateriallyTexturedBakedModel.java
@@ -2,7 +2,6 @@ package com.ldtteam.domumornamentum.client.model.baked;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.Lists;
 import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.ldtteam.domumornamentum.client.model.properties.ModProperties;
 import net.minecraft.client.Minecraft;
@@ -299,6 +298,20 @@ public class MateriallyTexturedBakedModel implements BakedModel {
         }
     }
     
+    /**
+     * Compute the set of RenderTypes required to render a given MaterialTextureData.
+     * <p>
+     * If the given MaterialTextureData is null or empty, this method returns a set containing only SOLID_ONLY.
+     * <p>
+     * Otherwise, this method returns a set containing all RenderTypes required by the baked models of all blocks in the MaterialTextureData,
+     * plus SOLID_ONLY.
+     * <p>
+     * The given RandomSource is used to generate randomness for the baked models.
+     *
+     * @param textureData the MaterialTextureData to compute the RenderTypes for
+     * @param rand the RandomSource to use for generating randomness for the baked models
+     * @return the set of RenderTypes required to render the given MaterialTextureData
+     */
     protected ChunkRenderTypeSet computeRenderTypesForMaterials(@Nullable MaterialTextureData textureData, RandomSource rand) 
     {
         if (textureData == null || textureData.isEmpty()) 

--- a/src/main/java/com/ldtteam/domumornamentum/client/model/baked/RetexturedBakedModelBuilder.java
+++ b/src/main/java/com/ldtteam/domumornamentum/client/model/baked/RetexturedBakedModelBuilder.java
@@ -74,11 +74,7 @@ public class RetexturedBakedModelBuilder {
                 return this.withOut(source);
             }
         } else {
-            if (bakedModel.getRenderTypes(new ItemStack(target), Minecraft.useShaderTransparency()).contains(this.renderType)) {
-                return this.with(source, bakedModel, defaultState);
-            } else {
-                return this.withOut(source);
-            }
+            return this.with(source, bakedModel, defaultState);
         }
 
     }


### PR DESCRIPTION
Items with transparency, cutout or gradients didn't always preview correctly in the architect's cutter window or display correctly in the inventory (although they displayed correctly in the world). This PR proposes to change the item rendering slightly to better handle more block types.  

See before and after pictures for a clearer explanation of the problem and the results of the fix.

This was tested by cycling through each architects cutter recipe (primary and variation) with logs and verifying that the cutter preview worked for everything (in addition to the testing with the custom textures in the pictures below.

If this PR is accepted, I'm happy to back port (but can't test the custom blocks in 1.20 - I can just regression test).

Full disclosure - I did have ChatGPT help me through chunks of this, as it is an area of Minecraft modding I am much less familiar with.

Before:

<img width="1664" height="703" alt="DO_Before_2" src="https://github.com/user-attachments/assets/43b36ab4-3e39-4880-a238-4620646dac20" />
<img width="1151" height="651" alt="DO_Before_1" src="https://github.com/user-attachments/assets/0ee0b5a9-9fbb-44db-ab84-c530adfd11bc" />
<img width="916" height="566" alt="DO_Before_3" src="https://github.com/user-attachments/assets/5dae0e32-f8d1-46c0-a6fb-015c262fbb78" />

After:
<img width="2086" height="1159" alt="DO_After_2" src="https://github.com/user-attachments/assets/b9ef1abc-7714-44ba-8058-102d5f80c9b5" />
<img width="1912" height="1002" alt="DO_After_1" src="https://github.com/user-attachments/assets/e65db6a5-e3e3-46ba-92fa-0683cd8105cf" />
<img width="1005" height="581" alt="DO_After_3" src="https://github.com/user-attachments/assets/a883a505-4ddc-45a3-9471-4fb818de6f6f" />
