### PR TITLE
Update Architects Cutter UI

### DIFF
--- a/src/api/java/com/ldtteam/domumornamentum/block/IModBlocks.java
+++ b/src/api/java/com/ldtteam/domumornamentum/block/IModBlocks.java
@@ -20,6 +20,20 @@ public interface IModBlocks
 
     List<? extends Block> getFramedLights();
 
+    Block getRoundPillar();
+
+    Block getVoxelPillar();
+
+    Block getSqaurePillar();
+
+    Block getAllBrickBlock();
+
+    Block getAllBrickDarkBlock();
+
+    Block getAllBrickStairBlock();
+
+    Block getAllBrickDarkStairBlock();
+
     Block getShingleSlab();
 
     Block getPaperWall();

--- a/src/main/java/com/ldtteam/domumornamentum/block/ModBlocks.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/ModBlocks.java
@@ -48,9 +48,6 @@ public final class ModBlocks implements IModBlocks {
     private static final List<Supplier<FloatingCarpetBlock>> FLOATING_CARPETS = new ArrayList<>();
     private static final List<Supplier<ExtraBlock>> EXTRA_TOP_BLOCKS = new ArrayList<>();
     private static final List<Supplier<BrickBlock>> BRICK = new ArrayList<>();
-    private static final List<Supplier<PillarBlock>> PILLARS = new ArrayList<>();
-    private static final List<Supplier<AllBrickBlock>> ALL_BRICK = new ArrayList<>();
-    private static final List<Supplier<AllBrickStairBlock>> ALL_BRICK_STAIR = new ArrayList<>();
 
     private static final ModBlocks INSTANCE = new ModBlocks();
 
@@ -77,6 +74,13 @@ public final class ModBlocks implements IModBlocks {
     private static final DeferredBlock<FancyTrapdoorBlock> FANCY_TRAPDOOR;
     private static final DeferredBlock<PaperWallBlock> TILED_PAPER_WALL;
     private static final DeferredBlock<DynamicTimberFrameBlock> DYNAMIC_TIMBER_FRAME;
+    private static final DeferredBlock<PillarBlock>        ROUND_PILLAR;
+    private static final DeferredBlock<PillarBlock>        VOXEL_PILLAR;
+    private static final DeferredBlock<PillarBlock>        SQUARE_PILLAR;
+    private static final DeferredBlock<AllBrickBlock>      ALL_BRICK;
+    private static final DeferredBlock<AllBrickBlock>      ALL_BRICK_DARK;
+    private static final DeferredBlock<AllBrickStairBlock> ALL_BRICK_STAIR;
+    private static final DeferredBlock<AllBrickStairBlock> ALL_BRICK_DARK_STAIR;
 
     static {
         ARCHITECTS_CUTTER = registerSimpleBlockItem("architectscutter", ArchitectsCutterBlock::new);
@@ -96,9 +100,9 @@ public final class ModBlocks implements IModBlocks {
         PAPER_WALL = registerCustomBlockItem("blockpaperwall", PaperWallBlock::new, b -> new PaperwallBlockItem(b, new Item.Properties()));
         TILED_PAPER_WALL = registerCustomBlockItem("blocktiledpaperwall", PaperWallBlock::new, b -> new PaperwallBlockItem(b, new Item.Properties()));
 
-        PILLARS.add(registerCustomBlockItem("blockpillar", PillarBlock::new, b -> new PillarBlockItem(b, new Item.Properties())));
-        PILLARS.add(registerCustomBlockItem("blockypillar", PillarBlock::new, b -> new PillarBlockItem(b, new Item.Properties())));
-        PILLARS.add(registerCustomBlockItem("squarepillar", PillarBlock::new, b -> new PillarBlockItem(b, new Item.Properties())));
+        ROUND_PILLAR = registerCustomBlockItem("blockpillar", PillarBlock::new, b -> new PillarBlockItem(b, new Item.Properties()));
+        VOXEL_PILLAR = registerCustomBlockItem("blockypillar", PillarBlock::new, b -> new PillarBlockItem(b, new Item.Properties()));
+        SQUARE_PILLAR = registerCustomBlockItem("squarepillar", PillarBlock::new, b -> new PillarBlockItem(b, new Item.Properties()));
 
         for (final ExtraBlockType blockType : ExtraBlockType.values()) {
             EXTRA_TOP_BLOCKS.add(registerCustomBlockItem(blockType.getSerializedName(), () -> new ExtraBlock(blockType), b -> new ExtraBlockItem(b, new Item.Properties())));
@@ -128,10 +132,10 @@ public final class ModBlocks implements IModBlocks {
         TRAPDOOR = registerCustomBlockItem("vanilla_trapdoors_compat", TrapdoorBlock::new, b -> new TrapdoorBlockItem(b, new Item.Properties()));
         DOOR = registerCustomBlockItem("vanilla_doors_compat", DoorBlock::new, b -> new DoorBlockItem(b, new Item.Properties()));
         PANEL = registerCustomBlockItem("panel", PanelBlock::new, b -> new PanelBlockItem(b, new Item.Properties()));
-        ALL_BRICK.add(registerCustomBlockItem("light_brick", AllBrickBlock::new, b -> new AllBrickBlockItem(b, new Item.Properties())));
-        ALL_BRICK.add(registerCustomBlockItem("dark_brick", AllBrickBlock::new, b -> new AllBrickBlockItem(b, new Item.Properties())));
-        ALL_BRICK_STAIR.add(registerCustomBlockItem("light_brick_stair", AllBrickStairBlock::new, b -> new AllBrickStairBlockItem(b, new Item.Properties())));
-        ALL_BRICK_STAIR.add(registerCustomBlockItem("dark_brick_stair", AllBrickStairBlock::new, b -> new AllBrickStairBlockItem(b, new Item.Properties())));
+        ALL_BRICK = (registerCustomBlockItem("light_brick", AllBrickBlock::new, b -> new AllBrickBlockItem(b, new Item.Properties())));
+        ALL_BRICK_DARK = (registerCustomBlockItem("dark_brick", AllBrickBlock::new, b -> new AllBrickBlockItem(b, new Item.Properties())));
+        ALL_BRICK_STAIR = (registerCustomBlockItem("light_brick_stair", AllBrickStairBlock::new, b -> new AllBrickStairBlockItem(b, new Item.Properties())));
+        ALL_BRICK_DARK_STAIR = (registerCustomBlockItem("dark_brick_stair", AllBrickStairBlock::new, b -> new AllBrickStairBlockItem(b, new Item.Properties())));
 
         POST = registerCustomBlockItem("post", PostBlock::new, b -> new PostBlockItem(b, new Item.Properties()));
 
@@ -142,7 +146,7 @@ public final class ModBlocks implements IModBlocks {
     /**
      * Specific item groups.
      */
-    public Map<ResourceLocation, List<ItemStack>> itemGroups = new TreeMap<>();
+    public Map<ResourceLocation, List<ItemStack>> itemGroups = new LinkedHashMap<>();
 
     /**
      * Private constructor to hide the implicit public one.
@@ -211,7 +215,49 @@ public final class ModBlocks implements IModBlocks {
     @Override
     public List<PillarBlock> getPillars()
     {
-        return ModBlocks.PILLARS.stream().map(Supplier::get).collect(Collectors.toList());
+        return List.of(VOXEL_PILLAR.get(), ROUND_PILLAR.get(), SQUARE_PILLAR.get());
+    }
+
+    @Override
+    public PillarBlock getRoundPillar()
+    {
+        return ROUND_PILLAR.get();
+    }
+
+    @Override
+    public PillarBlock getVoxelPillar()
+    {
+        return VOXEL_PILLAR.get();
+    }
+
+    @Override
+    public PillarBlock getSqaurePillar()
+    {
+        return SQUARE_PILLAR.get();
+    }
+
+    @Override
+    public AllBrickBlock getAllBrickBlock()
+    {
+        return ALL_BRICK.get();
+    }
+
+    @Override
+    public AllBrickBlock getAllBrickDarkBlock()
+    {
+        return ALL_BRICK_DARK.get();
+    }
+
+    @Override
+    public AllBrickStairBlock getAllBrickStairBlock()
+    {
+        return ALL_BRICK_STAIR.get();
+    }
+
+    @Override
+    public AllBrickStairBlock getAllBrickDarkStairBlock()
+    {
+        return ALL_BRICK_DARK_STAIR.get();
     }
 
     @Override
@@ -311,12 +357,12 @@ public final class ModBlocks implements IModBlocks {
 
     @Override
     public List<AllBrickBlock> getAllBrickBlocks() {
-        return ModBlocks.ALL_BRICK.stream().map(Supplier::get).toList();
+        return List.of(ALL_BRICK.get(), ALL_BRICK_DARK.get());
     }
 
     @Override
     public List<AllBrickStairBlock> getAllBrickStairBlocks() {
-        return ModBlocks.ALL_BRICK_STAIR.stream().map(Supplier::get).toList();
+        return List.of(ALL_BRICK_STAIR.get(), ALL_BRICK_DARK_STAIR.get());
     }
 
     @Override
@@ -352,9 +398,18 @@ public final class ModBlocks implements IModBlocks {
                             itemList.add(process(new ItemStack(item), texturedBlock));
                         }
                     }
-                    itemGroups.put(((IDoItem) item).getGroup(), itemList);
+                    itemGroups.put(((IDoItem) item).getGroup(), SortedBlocks.sortItems(itemList));
                 }
             });
+
+            final Map<ResourceLocation, List<ItemStack>> itemGroupMap = itemGroups;
+            List<ResourceLocation> ids = new ArrayList<>(itemGroupMap.keySet());
+            SortedBlocks.sortGroups(ids);
+            itemGroups = new LinkedHashMap<>();
+            for (final ResourceLocation id : ids)
+            {
+                itemGroups.put(id, itemGroupMap.get(id));
+            }
         }
         return itemGroups;
     }

--- a/src/main/java/com/ldtteam/domumornamentum/block/SortedBlocks.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/SortedBlocks.java
@@ -1,0 +1,262 @@
+package com.ldtteam.domumornamentum.block;
+
+import com.ldtteam.domumornamentum.DomumOrnamentum;
+import com.ldtteam.domumornamentum.block.decorative.*;
+import com.ldtteam.domumornamentum.block.types.*;
+import com.ldtteam.domumornamentum.block.vanilla.DoorBlock;
+import com.ldtteam.domumornamentum.block.vanilla.TrapdoorBlock;
+import com.ldtteam.domumornamentum.shingles.ShingleHeightType;
+import com.ldtteam.domumornamentum.util.BlockUtils;
+import com.ldtteam.domumornamentum.util.Constants;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Utility for visually sorting architects cutter groups
+ * Sort is arbitrary by most commonly used types
+ */
+public class SortedBlocks
+{
+    /**
+     * Sorting indexes for blocks, by block type through itemstack predicates to allow block type/state specifics
+     */
+    private static Map<Block, Function<ItemStack, Double>> sortingIndex = new HashMap<>();
+
+    /**
+     * Group indexes by ID
+     */
+    private static Map<ResourceLocation, Integer> groupSortingIndex = new HashMap<>();
+
+    /**
+     * Initializes sorting indexes
+     */
+    private static void init()
+    {
+        final ModBlocks modBlocks = ModBlocks.getInstance();
+
+        // Timberframes
+        groupSortingIndex.put(Constants.resLocDO("btimberframe"), 2);
+        for (final TimberFrameBlock block : modBlocks.getTimberFrames())
+        {
+            switch (block.getTimberFrameType())
+            {
+                case FRAMED -> simpleBlockIndex(block, 1);
+                case DOUBLE_CROSSED -> simpleBlockIndex(block, 2);
+                case PLAIN -> simpleBlockIndex(block, 3);
+                case SIDE_FRAMED -> simpleBlockIndex(block, 4);
+                case UP_GATED -> simpleBlockIndex(block, 5);
+                case DOWN_GATED -> simpleBlockIndex(block, 6);
+                case ONE_CROSSED_LR -> simpleBlockIndex(block, 7);
+                case ONE_CROSSED_RL -> simpleBlockIndex(block, 8);
+                case HORIZONTAL_PLAIN -> simpleBlockIndex(block, 9);
+                case SIDE_FRAMED_HORIZONTAL -> simpleBlockIndex(block, 10);
+            }
+        }
+        simpleBlockIndex(modBlocks.getDynamicTimberFrame(), 3.1);
+
+        // Vanilla blocks
+        groupSortingIndex.put(Constants.resLocDO("avanilla"), 1);
+        simpleBlockIndex(modBlocks.getStair(), 11);
+        simpleBlockIndex(modBlocks.getSlab(), 12);
+        simpleBlockIndex(modBlocks.getFence(), 13);
+        simpleBlockIndex(modBlocks.getFenceGate(), 14);
+        simpleBlockIndex(modBlocks.getWall(), 15);
+
+        // Shingles
+        groupSortingIndex.put(Constants.resLocDO("cshingle"), 3);
+        simpleBlockIndex(modBlocks.getShingle(ShingleHeightType.DEFAULT), 16);
+        simpleBlockIndex(modBlocks.getShingle(ShingleHeightType.FLAT), 17);
+        simpleBlockIndex(modBlocks.getShingle(ShingleHeightType.FLAT_LOWER), 18);
+        simpleBlockIndex(modBlocks.getShingle(ShingleHeightType.STEEP), 19);
+        simpleBlockIndex(modBlocks.getShingle(ShingleHeightType.STEEP_LOWER), 20);
+        simpleBlockIndex(modBlocks.getShingleSlab(), 21);
+
+        // Doors
+        groupSortingIndex.put(Constants.resLocDO("ddoor"), 5);
+        sortingIndex.put(modBlocks.getFancyDoor(), s -> {
+            double index = Double.MAX_VALUE;
+            switch (BlockUtils.getPropertyFromBlockStateTag(s, FancyDoorBlock.TYPE, FancyDoorType.CREEPER))
+            {
+                case FULL -> index = 22;
+
+                case CREEPER -> index = 27;
+            }
+            return index;
+        });
+        sortingIndex.put(modBlocks.getDoor(), s -> {
+            double index = Double.MAX_VALUE;
+            switch (BlockUtils.getPropertyFromBlockStateTag(s, DoorBlock.TYPE, DoorType.FULL))
+            {
+                case VERTICALLY_STRIPED -> index = 23;
+                case WAFFLE -> index = 24;
+                case PORT_MANTEAU -> index = 25;
+                case FULL -> index = 26;
+            }
+            return index;
+        });
+
+        // Trapdoors
+        groupSortingIndex.put(Constants.resLocDO("etrapdoor"), 4);
+        sortingIndex.put(modBlocks.getTrapdoor(), s -> {
+            double index = Double.MAX_VALUE;
+            switch (BlockUtils.getPropertyFromBlockStateTag(s, TrapdoorBlock.TYPE, TrapdoorType.WAFFLE))
+            {
+                case WAFFLE -> index = 27;
+                case HORIZONTALLY_SQUIGGLY_STRIPED -> index = 28;
+
+                case VERTICALLY_STRIPED -> index = 30;
+                case HORIZONTALLY_STRIPED -> index = 31;
+                case PORT_MANTEAU -> index = 32;
+                case VERTICAL_BARS -> index = 33;
+                case HORIZONTAL_BARS -> index = 34;
+                case VERTICALLY_SQUIGGLY_STRIPED -> index = 35;
+                case FULL -> index = 36;
+
+                case SLOT -> index = 38;
+                case PORTHOLE -> index = 39;
+                case MOULDING -> index = 40;
+                case COFFER -> index = 41;
+                case BOSS -> index = 42;
+                case ROUNDEL -> index = 43;
+            }
+            return index;
+        });
+        sortingIndex.put(modBlocks.getFancyTrapdoor(), s -> {
+            double index = Double.MAX_VALUE;
+            switch (BlockUtils.getPropertyFromBlockStateTag(s, FancyTrapdoorBlock.TYPE, FancyTrapdoorType.CREEPER))
+            {
+                case FULL -> index = 29;
+                case CREEPER -> index = 37;
+            }
+            return index;
+        });
+
+        // Panels
+        groupSortingIndex.put(Constants.resLocDO("fpanel"), 6);
+        sortingIndex.put(modBlocks.getPanel(), s -> {
+            double index = Double.MAX_VALUE;
+            switch (BlockUtils.getPropertyFromBlockStateTag(s, TrapdoorBlock.TYPE, TrapdoorType.WAFFLE))
+            {
+                case FULL -> index = 44;
+                case WAFFLE -> index = 45;
+                case VERTICALLY_STRIPED -> index = 46;
+                case HORIZONTALLY_STRIPED -> index = 47;
+                case PORT_MANTEAU -> index = 48;
+                case MOULDING -> index = 49;
+                case COFFER -> index = 50;
+                case VERTICAL_BARS -> index = 51;
+                case HORIZONTAL_BARS -> index = 52;
+                case VERTICALLY_SQUIGGLY_STRIPED -> index = 53;
+                case HORIZONTALLY_SQUIGGLY_STRIPED -> index = 54;
+                case SLOT -> index = 55;
+                case PORTHOLE -> index = 56;
+                case ROUNDEL -> index = 57;
+                case BOSS -> index = 58;
+            }
+            return index;
+        });
+
+        // Pillar
+        groupSortingIndex.put(Constants.resLocDO("gpillar"), 9);
+        simpleBlockIndex(modBlocks.getSqaurePillar(), 59);
+        simpleBlockIndex(modBlocks.getVoxelPillar(), 60);
+        simpleBlockIndex(modBlocks.getRoundPillar(), 61);
+
+        // Framed Panes(paper walls)
+        groupSortingIndex.put(Constants.resLocDO("hpaperwall"), 7);
+
+        // Lights
+        groupSortingIndex.put(Constants.resLocDO("ilight"), 8);
+        for (final FramedLightBlock framedLightBlock : modBlocks.getFramedLights())
+        {
+            double index = Double.MAX_VALUE;
+            switch (framedLightBlock.getFramedLightType())
+            {
+                case CENTER -> simpleBlockIndex(framedLightBlock, 62);
+                case LANTERN -> simpleBlockIndex(framedLightBlock, 63);
+                case FRAMED -> simpleBlockIndex(framedLightBlock, 64);
+                case VERTICAL -> simpleBlockIndex(framedLightBlock, 65);
+                case CROSSED -> simpleBlockIndex(framedLightBlock, 66);
+                case HORIZONTAL -> simpleBlockIndex(framedLightBlock, 67);
+                case FOUR -> simpleBlockIndex(framedLightBlock, 68);
+            }
+        }
+
+        // Bricks
+        groupSortingIndex.put(Constants.resLocDO("jbrick"), 11);
+        simpleBlockIndex(modBlocks.getAllBrickBlock(), 69);
+        simpleBlockIndex(modBlocks.getAllBrickStairBlock(), 70);
+        simpleBlockIndex(modBlocks.getAllBrickDarkBlock(), 71);
+        simpleBlockIndex(modBlocks.getAllBrickDarkStairBlock(), 72);
+        // Posts
+        groupSortingIndex.put(Constants.resLocDO("kpost"), 10);
+        sortingIndex.put(modBlocks.getPost(), s -> {
+            double index = Double.MAX_VALUE;
+            switch (BlockUtils.getPropertyFromBlockStateTag(s, PostBlock.TYPE, PostType.PLAIN))
+            {
+                case PLAIN -> index = 73;
+                case DOUBLE -> index = 74;
+                case QUAD -> index = 75;
+                case HEAVY -> index = 76;
+                case TURNED -> index = 77;
+                case PINCHED -> index = 78;
+            }
+            return index;
+        });
+    }
+
+    private static void simpleBlockIndex(Block block, double index)
+    {
+        sortingIndex.put(block, s -> index);
+    }
+
+    private static double getSortIndex(final ItemStack stack)
+    {
+        try
+        {
+            if (sortingIndex.isEmpty())
+            {
+                init();
+            }
+
+            if (stack.getItem() instanceof BlockItem blockItem)
+            {
+                return sortingIndex.getOrDefault(blockItem.getBlock(), s -> Double.MAX_VALUE).apply(stack);
+            }
+        }
+        catch (Exception e)
+        {
+            DomumOrnamentum.LOGGER.info("Failed to sort category for:" + stack, e);
+        }
+        return Double.MAX_VALUE;
+    }
+
+    /**
+     * Sorts the given list of stacks by their block sorting
+     *
+     * @param stackList
+     * @return
+     */
+    public static List<ItemStack> sortItems(final List<ItemStack> stackList)
+    {
+        stackList.sort(Comparator.comparingDouble(SortedBlocks::getSortIndex));
+        return stackList;
+    }
+
+    /***
+     * Sorts the group resourcelocation IDs
+     * @param ids
+     */
+    public static void sortGroups(final List<ResourceLocation> ids)
+    {
+        ids.sort(Comparator.comparingInt(id -> groupSortingIndex.get(id)));
+    }
+}

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/AllBrickBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/AllBrickBlock.java
@@ -38,7 +38,7 @@ public class AllBrickBlock extends AbstractBlock<AllBrickBlock> implements IMate
 {
 
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.ALL_BRICK_MATERIALS, Blocks.OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.ALL_BRICK_MATERIALS, Blocks.POLISHED_ANDESITE))
         .build();
 
     private final List<ItemStack> fillItemGroupCache = Lists.newArrayList();

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/AllBrickStairBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/AllBrickStairBlock.java
@@ -38,7 +38,7 @@ public class AllBrickStairBlock extends AbstractBlockStairs<AllBrickStairBlock> 
 {
 
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.ALL_BRICK_MATERIALS, Blocks.OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.ALL_BRICK_MATERIALS, Blocks.POLISHED_ANDESITE))
         .build();
 
     private final List<ItemStack> fillItemGroupCache = Lists.newArrayList();

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/DynamicTimberFrameBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/DynamicTimberFrameBlock.java
@@ -45,7 +45,7 @@ public class DynamicTimberFrameBlock extends AbstractBlock<DynamicTimberFrameBlo
 {
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
         .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.TIMBERFRAMES_FRAME, Blocks.OAK_PLANKS))
-        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/dark_oak_planks"), ModTags.TIMBERFRAMES_CENTER, Blocks.DARK_OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/dark_oak_planks"), ModTags.TIMBERFRAMES_CENTER, Blocks.WHITE_TERRACOTTA))
         .build();
 
     public static final DirectionProperty FACING = BlockStateProperties.FACING;

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
@@ -41,15 +41,15 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Objects;
 
-import static net.minecraft.world.level.block.Blocks.ACACIA_PLANKS;
-import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
+import static net.minecraft.world.level.block.Blocks.COPPER_BLOCK;
+import static net.minecraft.world.level.block.Blocks.SPRUCE_PLANKS;
 
 public class FancyDoorBlock extends AbstractBlockDoor<FancyDoorBlock> implements IMateriallyTexturedBlock, ICachedItemGroupBlock, EntityBlock
 {
     public static final EnumProperty<FancyDoorType>             TYPE       = EnumProperty.create(Constants.TYPE_BLOCK_PROPERTY, FancyDoorType.class);
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.FANCY_DOORS_MATERIALS, OAK_PLANKS))
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/acacia_planks"), ModTags.FANCY_DOORS_MATERIALS, ACACIA_PLANKS, true))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.FANCY_DOORS_MATERIALS, SPRUCE_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/acacia_planks"), ModTags.FANCY_DOORS_MATERIALS, COPPER_BLOCK, true))
                                                                                .build();
 
     private final List<ItemStack> fillItemGroupCache = Lists.newArrayList();

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
@@ -38,15 +38,15 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import static net.minecraft.world.level.block.Blocks.ACACIA_PLANKS;
-import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
+import static net.minecraft.world.level.block.Blocks.QUARTZ_BLOCK;
+import static net.minecraft.world.level.block.Blocks.STRIPPED_OAK_WOOD;
 
 public class FancyTrapdoorBlock extends AbstractBlockTrapdoor<FancyTrapdoorBlock> implements IMateriallyTexturedBlock, ICachedItemGroupBlock, EntityBlock
 {
     public static final EnumProperty<FancyTrapdoorType> TYPE = EnumProperty.create(Constants.TYPE_BLOCK_PROPERTY, FancyTrapdoorType.class);
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.FANCY_TRAPDOORS_MATERIALS, OAK_PLANKS))
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/acacia_planks"), ModTags.FANCY_TRAPDOORS_MATERIALS, ACACIA_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.FANCY_TRAPDOORS_MATERIALS, STRIPPED_OAK_WOOD))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/acacia_planks"), ModTags.FANCY_TRAPDOORS_MATERIALS, QUARTZ_BLOCK))
                                                                                .build();
 
     private final List<ItemStack> fillItemGroupCache = Lists.newArrayList();

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FramedLightBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FramedLightBlock.java
@@ -2,11 +2,9 @@ package com.ldtteam.domumornamentum.block.decorative;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.ldtteam.domumornamentum.block.AbstractBlock;
-import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
-import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
-import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
+import com.ldtteam.domumornamentum.block.*;
 import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
+import com.ldtteam.domumornamentum.block.types.BrickType;
 import com.ldtteam.domumornamentum.block.types.FramedLightType;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
 import com.ldtteam.domumornamentum.recipe.architectscutter.ArchitectsCutterRecipeBuilder;
@@ -44,10 +42,7 @@ import java.util.List;
 public class FramedLightBlock extends AbstractBlock<FramedLightBlock> implements IMateriallyTexturedBlock, ICachedItemGroupBlock, EntityBlock
 {
 
-    public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.TIMBERFRAMES_FRAME, Blocks.OAK_PLANKS))
-        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/glowstone"), ModTags.FRAMED_LIGHT_CENTER, Blocks.GLOWSTONE))
-        .build();
+    private static List<IMateriallyTexturedBlockComponent> COMPONENTS = null;
 
     /**
      * The hardness this block has.
@@ -83,6 +78,19 @@ public class FramedLightBlock extends AbstractBlock<FramedLightBlock> implements
     @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
+        if (COMPONENTS == null)
+        {
+            COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
+                .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.TIMBERFRAMES_FRAME,
+                    ModBlocks.getInstance()
+                        .getBricks()
+                        .stream()
+                        .filter(b -> (b instanceof BrickBlock brickBLock && brickBLock.getType() == BrickType.CREAM_STONE))
+                        .findFirst()
+                        .get()))
+                .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/glowstone"), ModTags.FRAMED_LIGHT_CENTER, Blocks.GLOWSTONE))
+                .build();
+        }
         return COMPONENTS;
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PanelBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PanelBlock.java
@@ -43,14 +43,14 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
+import static net.minecraft.world.level.block.Blocks.STRIPPED_OAK_WOOD;
 
 public class PanelBlock extends AbstractPanelBlockTrapdoor<PanelBlock> implements IMateriallyTexturedBlock, ICachedItemGroupBlock, EntityBlock
 {
     public static final MapCodec<PanelBlock> CODEC = simpleCodec(PanelBlock::new);
     public static final EnumProperty<TrapdoorType>              TYPE       = EnumProperty.create(Constants.TYPE_BLOCK_PROPERTY, TrapdoorType.class);
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.TRAPDOORS_MATERIALS, OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.TRAPDOORS_MATERIALS, STRIPPED_OAK_WOOD))
                                                                                .build();
 
     private final List<ItemStack> fillItemGroupCache = Lists.newArrayList();

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PaperWallBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PaperWallBlock.java
@@ -42,8 +42,8 @@ import java.util.List;
 public class PaperWallBlock extends AbstractBlockPane<PaperWallBlock> implements IMateriallyTexturedBlock, ICachedItemGroupBlock, EntityBlock
 {
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.PAPERWALL_FRAME, Blocks.OAK_PLANKS))
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/dark_oak_planks"), ModTags.PAPERWALL_CENTER, Blocks.DARK_OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.PAPERWALL_FRAME, Blocks.STRIPPED_SPRUCE_WOOD))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/dark_oak_planks"), ModTags.PAPERWALL_CENTER, Blocks.GLASS))
                                                                                .build();
 
     private final List<ItemStack> fillItemGroupCache = Lists.newArrayList();

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PillarBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PillarBlock.java
@@ -22,11 +22,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.Explosion;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.*;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.EntityBlock;
@@ -50,7 +46,7 @@ public class PillarBlock extends AbstractBlock<PillarBlock> implements IMaterial
 {
 
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.PILLAR_MATERIALS, Blocks.OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.PILLAR_MATERIALS, Blocks.STONE_BRICKS))
         .build();
 
     /**

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleBlock.java
@@ -2,11 +2,9 @@ package com.ldtteam.domumornamentum.block.decorative;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.ldtteam.domumornamentum.block.AbstractBlockStairs;
-import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
-import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
-import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
+import com.ldtteam.domumornamentum.block.*;
 import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
+import com.ldtteam.domumornamentum.block.types.ExtraBlockType;
 import com.ldtteam.domumornamentum.block.types.ShingleShapeType;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
 import com.ldtteam.domumornamentum.recipe.architectscutter.ArchitectsCutterRecipeBuilder;
@@ -45,10 +43,7 @@ import java.util.List;
  */
 public class ShingleBlock extends AbstractBlockStairs<ShingleBlock> implements IMateriallyTexturedBlock, ICachedItemGroupBlock, EntityBlock
 {
-    public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/clay"), ModTags.SHINGLES_ROOF, Blocks.CLAY))
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.SHINGLES_SUPPORT, Blocks.OAK_PLANKS))
-                                                                               .build();
+    private static List<IMateriallyTexturedBlockComponent> COMPONENTS = null;
 
     /**
      * The hardness this block has.
@@ -107,6 +102,20 @@ public class ShingleBlock extends AbstractBlockStairs<ShingleBlock> implements I
     @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
+        if (COMPONENTS == null)
+        {
+            COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
+                .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/clay"), ModTags.SHINGLES_ROOF,
+                    ModBlocks.getInstance()
+                        .getExtraTopBlocks()
+                        .stream()
+                        .filter(b -> (b instanceof ExtraBlock extraBlock && extraBlock.getType() == ExtraBlockType.BASE_BRICK))
+                        .findFirst()
+                        .get()))
+                .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.SHINGLES_SUPPORT, Blocks.OAK_PLANKS))
+                .build();
+        }
+
         return COMPONENTS;
     }
 
@@ -138,7 +147,7 @@ public class ShingleBlock extends AbstractBlockStairs<ShingleBlock> implements I
     @Override
     public void buildRecipes(final RecipeOutput recipeOutput)
     {
-        new ArchitectsCutterRecipeBuilder(this, RecipeCategory.BUILDING_BLOCKS).count(COMPONENTS.size() * 2).save(recipeOutput);        
+        new ArchitectsCutterRecipeBuilder(this, RecipeCategory.BUILDING_BLOCKS).count(getComponents().size() * 2).save(recipeOutput);
     }
 
     @Override
@@ -158,7 +167,7 @@ public class ShingleBlock extends AbstractBlockStairs<ShingleBlock> implements I
 
     @Override
     public IMateriallyTexturedBlockComponent getMainComponent() {
-        return COMPONENTS.get(0);
+        return getComponents().get(0);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleSlabBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/ShingleSlabBlock.java
@@ -2,11 +2,9 @@ package com.ldtteam.domumornamentum.block.decorative;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.ldtteam.domumornamentum.block.AbstractBlockDirectional;
-import com.ldtteam.domumornamentum.block.ICachedItemGroupBlock;
-import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
-import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
+import com.ldtteam.domumornamentum.block.*;
 import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
+import com.ldtteam.domumornamentum.block.types.ExtraBlockType;
 import com.ldtteam.domumornamentum.block.types.ShingleSlabShapeType;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
 import com.ldtteam.domumornamentum.recipe.architectscutter.ArchitectsCutterRecipeBuilder;
@@ -28,11 +26,7 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.SimpleWaterloggedBlock;
-import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -49,19 +43,10 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
-
 import java.util.List;
 
-import static com.ldtteam.domumornamentum.block.types.ShingleSlabShapeType.CURVED;
-import static com.ldtteam.domumornamentum.block.types.ShingleSlabShapeType.FOUR_WAY;
-import static com.ldtteam.domumornamentum.block.types.ShingleSlabShapeType.ONE_WAY;
-import static com.ldtteam.domumornamentum.block.types.ShingleSlabShapeType.THREE_WAY;
-import static com.ldtteam.domumornamentum.block.types.ShingleSlabShapeType.TOP;
-import static com.ldtteam.domumornamentum.block.types.ShingleSlabShapeType.TWO_WAY;
-import static net.minecraft.core.Direction.EAST;
-import static net.minecraft.core.Direction.NORTH;
-import static net.minecraft.core.Direction.SOUTH;
-import static net.minecraft.core.Direction.WEST;
+import static com.ldtteam.domumornamentum.block.types.ShingleSlabShapeType.*;
+import static net.minecraft.core.Direction.*;
 
 /**
  * Decorative block
@@ -69,10 +54,7 @@ import static net.minecraft.core.Direction.WEST;
 public class ShingleSlabBlock extends AbstractBlockDirectional<ShingleSlabBlock> implements SimpleWaterloggedBlock, IMateriallyTexturedBlock, ICachedItemGroupBlock, EntityBlock
 {
     public static final MapCodec<ShingleSlabBlock> CODEC = simpleCodec(ShingleSlabBlock::new);
-    public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.SHINGLES_ROOF, Blocks.OAK_PLANKS))
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/dark_oak_planks"), ModTags.SHINGLES_SUPPORT, Blocks.DARK_OAK_PLANKS))
-                                                                               .build();
+    private static List<IMateriallyTexturedBlockComponent> COMPONENTS = null;
 
     /**
      * The SHAPEs of the shingle slab.
@@ -298,6 +280,18 @@ public class ShingleSlabBlock extends AbstractBlockDirectional<ShingleSlabBlock>
     @Override
     public @NotNull List<IMateriallyTexturedBlockComponent> getComponents()
     {
+        if (COMPONENTS == null)
+        {
+            COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
+                .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.SHINGLES_ROOF, ModBlocks.getInstance()
+                    .getExtraTopBlocks()
+                    .stream()
+                    .filter(b -> (b instanceof ExtraBlock extraBlock && extraBlock.getType() == ExtraBlockType.BASE_BRICK))
+                    .findFirst()
+                    .get()))
+                .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/dark_oak_planks"), ModTags.SHINGLES_SUPPORT, Blocks.OAK_PLANKS))
+                .build();
+        }
         return COMPONENTS;
     }
 
@@ -323,7 +317,7 @@ public class ShingleSlabBlock extends AbstractBlockDirectional<ShingleSlabBlock>
     @Override
     public void buildRecipes(final RecipeOutput recipeOutput)
     {
-        new ArchitectsCutterRecipeBuilder(this, RecipeCategory.BUILDING_BLOCKS).count(COMPONENTS.size() * 2).save(recipeOutput);
+        new ArchitectsCutterRecipeBuilder(this, RecipeCategory.BUILDING_BLOCKS).count(getComponents().size() * 2).save(recipeOutput);
     }
 
     @Override
@@ -343,7 +337,7 @@ public class ShingleSlabBlock extends AbstractBlockDirectional<ShingleSlabBlock>
 
     @Override
     public IMateriallyTexturedBlockComponent getMainComponent() {
-        return COMPONENTS.get(0);
+        return getComponents().get(0);
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/TimberFrameBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/TimberFrameBlock.java
@@ -25,12 +25,7 @@ import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.world.level.block.Rotation;
-import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -53,7 +48,7 @@ public class TimberFrameBlock extends AbstractBlock<TimberFrameBlock> implements
 
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
         .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.TIMBERFRAMES_FRAME, Blocks.OAK_PLANKS))
-        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/dark_oak_planks"), ModTags.TIMBERFRAMES_CENTER, Blocks.DARK_OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/dark_oak_planks"), ModTags.TIMBERFRAMES_CENTER, Blocks.WHITE_TERRACOTTA))
         .build();
 
     public static final DirectionProperty FACING = BlockStateProperties.FACING;

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
@@ -41,13 +41,13 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Objects;
 
-import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
+import static net.minecraft.world.level.block.Blocks.STRIPPED_OAK_WOOD;
 
 public class DoorBlock extends AbstractBlockDoor<DoorBlock> implements IMateriallyTexturedBlock, ICachedItemGroupBlock, EntityBlock
 {
     public static final EnumProperty<DoorType> TYPE = EnumProperty.create(Constants.TYPE_BLOCK_PROPERTY, DoorType.class);
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.DOORS_MATERIALS, OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.DOORS_MATERIALS, STRIPPED_OAK_WOOD))
                                                                                .build();
 
     private final List<ItemStack> fillItemGroupCache = Lists.newArrayList();

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceBlock.java
@@ -34,12 +34,12 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
+import static net.minecraft.world.level.block.Blocks.STRIPPED_OAK_WOOD;
 
 public class FenceBlock extends AbstractBlockFence<FenceBlock> implements IMateriallyTexturedBlock, EntityBlock, ICachedItemGroupBlock
 {
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.FENCE_MATERIALS, OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.FENCE_MATERIALS, STRIPPED_OAK_WOOD))
                                                                                .build();
 
     private final List<ItemStack> fillItemGroupCache = Lists.newArrayList();

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceGateBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/FenceGateBlock.java
@@ -33,12 +33,12 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
+import static net.minecraft.world.level.block.Blocks.STRIPPED_OAK_WOOD;
 
 public class FenceGateBlock extends AbstractBlockFenceGate<FenceGateBlock> implements IMateriallyTexturedBlock, EntityBlock, ICachedItemGroupBlock
 {
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.FENCE_GATE_MATERIALS, OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.FENCE_GATE_MATERIALS, STRIPPED_OAK_WOOD))
                                                                                .build();
 
     private final List<ItemStack> fillItemGroupCache = Lists.newArrayList();

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/SlabBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/SlabBlock.java
@@ -36,12 +36,12 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
+import static net.minecraft.world.level.block.Blocks.STRIPPED_OAK_WOOD;
 
 public class SlabBlock extends AbstractBlockSlab<SlabBlock> implements IMateriallyTexturedBlock, EntityBlock, ICachedItemGroupBlock
 {
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.SLAB_MATERIALS, OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.SLAB_MATERIALS, STRIPPED_OAK_WOOD))
                                                                                .build();
 
     private final List<ItemStack> fillItemGroupCache = Lists.newArrayList();

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/StairBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/StairBlock.java
@@ -34,10 +34,12 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
+import static net.minecraft.world.level.block.Blocks.STRIPPED_OAK_WOOD;
 
 public class StairBlock extends net.minecraft.world.level.block.StairBlock implements IMateriallyTexturedBlock, EntityBlock, ICachedItemGroupBlock, IDOBlock<StairBlock>
 {
-    private static IMateriallyTexturedBlockComponent MATERIAL_COMPONENT = new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.STAIRS_MATERIALS, OAK_PLANKS);
+    private static IMateriallyTexturedBlockComponent MATERIAL_COMPONENT =
+        new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.STAIRS_MATERIALS, STRIPPED_OAK_WOOD);
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
                                                                                .add(MATERIAL_COMPONENT)
                                                                                .build();

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
@@ -38,13 +38,13 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
+import static net.minecraft.world.level.block.Blocks.STRIPPED_JUNGLE_WOOD;
 
 public class TrapdoorBlock extends AbstractBlockTrapdoor<TrapdoorBlock> implements IMateriallyTexturedBlock, ICachedItemGroupBlock, EntityBlock
 {
     public static final EnumProperty<TrapdoorType>              TYPE       = EnumProperty.create(Constants.TYPE_BLOCK_PROPERTY, TrapdoorType.class);
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-      .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.TRAPDOORS_MATERIALS, OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.TRAPDOORS_MATERIALS, STRIPPED_JUNGLE_WOOD))
       .build();
 
     private final List<ItemStack> fillItemGroupCache = Lists.newArrayList();

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/WallBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/WallBlock.java
@@ -37,12 +37,12 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-import static net.minecraft.world.level.block.Blocks.OAK_PLANKS;
+import static net.minecraft.world.level.block.Blocks.STRIPPED_OAK_WOOD;
 
 public class WallBlock extends AbstractBlockWall<WallBlock> implements IMateriallyTexturedBlock, EntityBlock, ICachedItemGroupBlock
 {
     public static final List<IMateriallyTexturedBlockComponent> COMPONENTS = ImmutableList.<IMateriallyTexturedBlockComponent>builder()
-                                                                               .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.WALL_MATERIALS, OAK_PLANKS))
+        .add(new SimpleRetexturableComponent(ResourceLocation.withDefaultNamespace("block/oak_planks"), ModTags.WALL_MATERIALS, STRIPPED_OAK_WOOD))
                                                                                .build();
 
     public static ImmutableMap<Direction, EnumProperty<WallSide>> PROPERTIES = ImmutableMap.of(

--- a/src/main/java/com/ldtteam/domumornamentum/container/ArchitectsCutterContainer.java
+++ b/src/main/java/com/ldtteam/domumornamentum/container/ArchitectsCutterContainer.java
@@ -22,7 +22,10 @@ import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.ldtteam.domumornamentum.util.GuiConstants.*;
@@ -198,7 +201,9 @@ public class ArchitectsCutterContainer extends AbstractContainerMenu
         if (id < ModBlocks.getInstance().getOrComputeItemGroups().size())
         {
             this.selectGroup(new ArrayList<>(ModBlocks.getInstance().getOrComputeItemGroups().keySet()).get(id));
-            this.outputInventorySlot.set(ItemStack.EMPTY); // clear output
+            this.outputInventorySlot.set(ItemStack.EMPTY);
+            this.selectVariant(ModBlocks.getInstance().getOrComputeItemGroups().get(getCurrentGroup()).get(0));
+            updateRecipeResultSlot();
             broadcastChanges();
             return true;
         }
@@ -258,6 +263,7 @@ public class ArchitectsCutterContainer extends AbstractContainerMenu
     }
 
     private void updateRecipeResultSlot() {
+        this.outputInventorySlot.set(ItemStack.EMPTY);
         if (!this.recipes.isEmpty() && this.currentVariant != null && this.currentVariant.getItem() instanceof BlockItem) {
             for (final RecipeHolder<ArchitectsCutterRecipe> recipeHolder : recipes)
             {
@@ -275,9 +281,6 @@ public class ArchitectsCutterContainer extends AbstractContainerMenu
                     }
                 }
             }
-
-        } else {
-            this.outputInventorySlot.set(ItemStack.EMPTY);
         }
 
         this.broadcastChanges();


### PR DESCRIPTION
Update Architects Cutter UI:
- Blocks now have better default textures chosen to make it easier to recognize blocks and are similar to frequently used variants in builds
- Groups and Variants now have a sort order and are now sorted by most commonly used. Trapdoors and Panels are now more distinct and harder to confuse.
- Switching groups now does update the new group's variants with the current input block and also selects the first variant in the list

Previous:
<img width="944" height="256" alt="image" src="https://github.com/user-attachments/assets/ef6f9f67-1f49-4a7c-aaed-581d40f659a2" />

New:
<img width="940" height="254" alt="image" src="https://github.com/user-attachments/assets/e0fa18b2-c519-4edb-b303-b2e819f60291" />
