### PR TITLE
Fix enum crashes

### DIFF
--- a/src/main/java/com/ldtteam/domumornamentum/block/DOStairBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/DOStairBlock.java
@@ -56,7 +56,7 @@ public class DOStairBlock extends Block implements SimpleWaterloggedBlock
                                     .setValue(FACING, Direction.NORTH)
                                     .setValue(HALF, Half.BOTTOM)
                                     .setValue(SHAPE, StairsShape.STRAIGHT)
-                                    .setValue(WATERLOGGED, Boolean.valueOf(false)));
+            .setValue(WATERLOGGED, false));
         this.stateSupplier = state;
     }
 
@@ -128,7 +128,7 @@ public class DOStairBlock extends Block implements SimpleWaterloggedBlock
                                     direction != Direction.DOWN && (direction == Direction.UP || !(p_56872_.getClickLocation().y - (double) blockpos.getY() > 0.5D))
                                       ? Half.BOTTOM
                                       : Half.TOP)
-                                  .setValue(WATERLOGGED, Boolean.valueOf(fluidstate.getType() == Fluids.WATER));
+            .setValue(WATERLOGGED, fluidstate.getType() == Fluids.WATER);
         return blockstate.setValue(SHAPE, getStairsShape(blockstate, p_56872_.getLevel(), blockpos));
     }
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyDoorBlock.java
@@ -9,6 +9,7 @@ import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlock;
 import com.ldtteam.domumornamentum.block.IMateriallyTexturedBlockComponent;
 import com.ldtteam.domumornamentum.block.components.SimpleRetexturableComponent;
 import com.ldtteam.domumornamentum.block.types.FancyDoorType;
+import com.ldtteam.domumornamentum.block.types.FancyTrapdoorType;
 import com.ldtteam.domumornamentum.client.model.data.MaterialTextureData;
 import com.ldtteam.domumornamentum.entity.block.MateriallyTexturedBlockEntity;
 import com.ldtteam.domumornamentum.recipe.FinishedDORecipe;
@@ -114,12 +115,12 @@ public class FancyDoorBlock extends AbstractBlockDoor<FancyDoorBlock> implements
         final String type = stack.getOrCreateTag().getString("type");
         worldIn.setBlock(
           pos,
-          worldIn.getBlockState(pos).setValue(TYPE, FancyDoorType.valueOf(type.toUpperCase())),
+            worldIn.getBlockState(pos).setValue(TYPE, FancyDoorType.fromString(type, FancyDoorType.FULL)),
           Block.UPDATE_ALL
         );
         worldIn.setBlock(
           pos.above(),
-          worldIn.getBlockState(pos.above()).setValue(TYPE, FancyDoorType.valueOf(type.toUpperCase())),
+            worldIn.getBlockState(pos.above()).setValue(TYPE, FancyDoorType.fromString(type, FancyDoorType.FULL)),
           Block.UPDATE_ALL
         );
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/FancyTrapdoorBlock.java
@@ -111,7 +111,7 @@ public class FancyTrapdoorBlock extends AbstractBlockTrapdoor<FancyTrapdoorBlock
         final String type = stack.getOrCreateTag().getString("type");
         worldIn.setBlock(
           pos,
-          state.setValue(TYPE, FancyTrapdoorType.valueOf(type.toUpperCase())),
+            state.setValue(TYPE, FancyTrapdoorType.fromString(type, FancyTrapdoorType.FULL)),
           Block.UPDATE_ALL
         );
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PanelBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PanelBlock.java
@@ -119,7 +119,8 @@ public class PanelBlock extends AbstractPanelBlockTrapdoor<PanelBlock> implement
     @Override
     public BlockState getStateForPlacement(final @NotNull BlockPlaceContext context)
     {
-        final BlockState state = super.getStateForPlacement(context).setValue(TYPE, TrapdoorType.valueOf(context.getItemInHand().getOrCreateTag().getString("type")));
+        final BlockState state =
+            super.getStateForPlacement(context).setValue(TYPE, TrapdoorType.fromString(context.getItemInHand().getOrCreateTag().getString("type"), TrapdoorType.FULL));
         final Vec3 offsetPos = context.getClickLocation().subtract(Vec3.atLowerCornerOf(context.getClickedPos()));
         if (context.getClickedFace().getAxis().isHorizontal())
         {

--- a/src/main/java/com/ldtteam/domumornamentum/block/decorative/PostBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/decorative/PostBlock.java
@@ -123,7 +123,7 @@ public class PostBlock extends AbstractPostBlock<PostBlock> implements IMaterial
 
         worldIn.setBlock(
           pos,
-          state.setValue(TYPE, PostType.valueOf(type.toUpperCase())),
+            state.setValue(TYPE, PostType.fromString(type, PostType.PLAIN)),
           Block.UPDATE_ALL
         );
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/BrickType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/BrickType.java
@@ -1,9 +1,12 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 /**
  * Creates special blocks for shingles and timberframes.
@@ -49,5 +52,12 @@ public enum BrickType implements StringRepresentable
     public Item getIngredient2()
     {
         return this.ingredient2;
+    }
+
+    private static final Map<String, BrickType> ID_MAP = EnumHelper.createMap(BrickType.class);
+
+    public static BrickType fromString(final String s, final BrickType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/DoorType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/DoorType.java
@@ -1,9 +1,11 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public enum DoorType implements StringRepresentable
@@ -32,5 +34,12 @@ public enum DoorType implements StringRepresentable
         return Arrays.stream(parts)
           .map(StringUtils::capitalize)
           .collect(Collectors.joining(" "));
+    }
+
+    private static final Map<String, DoorType> ID_MAP = EnumHelper.createMap(DoorType.class);
+
+    public static DoorType fromString(final String s, final DoorType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/ExtraBlockType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/ExtraBlockType.java
@@ -1,5 +1,6 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
@@ -9,6 +10,8 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
 
 /**
  * Creates special blocks for shingles and timberframes.
@@ -118,5 +121,12 @@ public enum ExtraBlockType implements StringRepresentable
             properties.noCollission();
         }
         return properties;
+    }
+
+    private static final Map<String, ExtraBlockType> ID_MAP = EnumHelper.createMap(ExtraBlockType.class);
+
+    public static ExtraBlockType fromString(final String s, final ExtraBlockType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/FancyDoorType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/FancyDoorType.java
@@ -1,9 +1,11 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public enum FancyDoorType implements StringRepresentable
@@ -30,5 +32,12 @@ public enum FancyDoorType implements StringRepresentable
         return Arrays.stream(parts)
           .map(StringUtils::capitalize)
           .collect(Collectors.joining(" "));
+    }
+
+    private static final Map<String, FancyDoorType> ID_MAP = EnumHelper.createMap(FancyDoorType.class);
+
+    public static FancyDoorType fromString(final String s, final FancyDoorType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/FancyTrapdoorType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/FancyTrapdoorType.java
@@ -1,9 +1,11 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public enum FancyTrapdoorType implements StringRepresentable
@@ -30,5 +32,12 @@ public enum FancyTrapdoorType implements StringRepresentable
         return Arrays.stream(parts)
           .map(StringUtils::capitalize)
           .collect(Collectors.joining(" "));
+    }
+
+    private static final Map<String, FancyTrapdoorType> ID_MAP = EnumHelper.createMap(FancyTrapdoorType.class);
+
+    public static FancyTrapdoorType fromString(final String s, final FancyTrapdoorType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/FramedLightType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/FramedLightType.java
@@ -1,7 +1,10 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 // Creates types for TimberFrame with different variants of wood and texture
 
@@ -40,5 +43,12 @@ public enum FramedLightType implements StringRepresentable
     public String getLangName()
     {
         return this.langName;
+    }
+
+    private static final Map<String, FramedLightType> ID_MAP = EnumHelper.createMap(FramedLightType.class);
+
+    public static FramedLightType fromString(final String s, final FramedLightType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/PaperwallType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/PaperwallType.java
@@ -1,8 +1,11 @@
 package com.ldtteam.domumornamentum.block.types;
 
 import com.ldtteam.domumornamentum.block.decorative.PaperWallBlock;
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 /**
  * Types that the {@link PaperWallBlock} supports
@@ -36,5 +39,12 @@ public enum PaperwallType implements StringRepresentable
     public String getName()
     {
         return this.name;
+    }
+
+    private static final Map<String, PaperwallType> ID_MAP = EnumHelper.createMap(PaperwallType.class);
+
+    public static PaperwallType fromString(final String s, final PaperwallType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/PillarShapeType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/PillarShapeType.java
@@ -1,7 +1,10 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 public enum PillarShapeType implements StringRepresentable
 {
@@ -28,4 +31,10 @@ public enum PillarShapeType implements StringRepresentable
         return this.name + "_spec";
     }
 
+    private static final Map<String, PillarShapeType> ID_MAP = EnumHelper.createMap(PillarShapeType.class);
+
+    public static PillarShapeType fromString(final String s, final PillarShapeType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
+    }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/PostType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/PostType.java
@@ -1,8 +1,10 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import org.apache.commons.lang3.StringUtils;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -38,5 +40,12 @@ public enum PostType implements StringRepresentable
         return Arrays.stream(parts)
           .map(StringUtils::capitalize)
           .collect(Collectors.joining(" "));
+    }
+
+    private static final Map<String, PostType> ID_MAP = EnumHelper.createMap(PostType.class);
+
+    public static PostType fromString(final String s, final PostType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/ShingleFaceType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/ShingleFaceType.java
@@ -1,7 +1,10 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 /**
  * Face types used by both Shingles and Shingle Slabs.
@@ -138,5 +141,12 @@ public enum ShingleFaceType implements StringRepresentable
     public boolean isDyed()
     {
         return this.isDyed;
+    }
+
+    private static final Map<String, ShingleFaceType> ID_MAP = EnumHelper.createMap(ShingleFaceType.class);
+
+    public static ShingleFaceType fromString(final String s, final ShingleFaceType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/ShingleSlabShapeType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/ShingleSlabShapeType.java
@@ -1,7 +1,10 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 /**
  * Shape types used by the Shingle Slabs.
@@ -36,5 +39,12 @@ public enum ShingleSlabShapeType implements StringRepresentable
     public String getName()
     {
         return this.name;
+    }
+
+    private static final Map<String, ShingleSlabShapeType> ID_MAP = EnumHelper.createMap(ShingleSlabShapeType.class);
+
+    public static ShingleSlabShapeType fromString(final String s, final ShingleSlabShapeType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/ShingleWoodType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/ShingleWoodType.java
@@ -1,7 +1,10 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 /**
  * Wood types used by Shingles
@@ -80,5 +83,12 @@ public enum ShingleWoodType implements StringRepresentable
     public String getRecipeIngredient()
     {
         return this.recipeIngredient;
+    }
+
+    private static final Map<String, ShingleWoodType> ID_MAP = EnumHelper.createMap(ShingleWoodType.class);
+
+    public static ShingleWoodType fromString(final String s, final ShingleWoodType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/TimberFrameType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/TimberFrameType.java
@@ -1,7 +1,10 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 // Creates types for TimberFrame with different variants of wood and texture
 
@@ -60,5 +63,12 @@ public enum TimberFrameType implements StringRepresentable
     public boolean isRotatable()
     {
         return this.rotatable;
+    }
+
+    private static final Map<String, TimberFrameType> ID_MAP = EnumHelper.createMap(TimberFrameType.class);
+
+    public static TimberFrameType fromString(final String s, final TimberFrameType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/types/TrapdoorType.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/types/TrapdoorType.java
@@ -1,10 +1,11 @@
 package com.ldtteam.domumornamentum.block.types;
 
+import com.ldtteam.domumornamentum.util.EnumHelper;
 import net.minecraft.util.StringRepresentable;
-import net.minecraft.util.StringUtil;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public enum TrapdoorType implements StringRepresentable
@@ -35,14 +36,23 @@ public enum TrapdoorType implements StringRepresentable
         return serializationName;
     }
 
-    public String getTranslationKeySuffix() {
+    public String getTranslationKeySuffix()
+    {
         return getSerializedName().replace("_", ".");
     }
 
-    public String getDefaultEnglishTranslation() {
+    public String getDefaultEnglishTranslation()
+    {
         final String[] parts = getSerializedName().split("_");
         return Arrays.stream(parts)
-          .map(StringUtils::capitalize)
-          .collect(Collectors.joining(" "));
+            .map(StringUtils::capitalize)
+            .collect(Collectors.joining(" "));
+    }
+
+    private static final Map<String, TrapdoorType> ID_MAP = EnumHelper.createMap(TrapdoorType.class);
+
+    public static TrapdoorType fromString(final String s, final TrapdoorType defaultType)
+    {
+        return EnumHelper.fromString(ID_MAP, s, defaultType);
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/DoorBlock.java
@@ -107,12 +107,12 @@ public class DoorBlock extends AbstractBlockDoor<DoorBlock> implements IMaterial
         final String type = stack.getOrCreateTag().getString("type");
         worldIn.setBlock(
           pos,
-          worldIn.getBlockState(pos).setValue(TYPE, DoorType.valueOf(type.toUpperCase())),
+            worldIn.getBlockState(pos).setValue(TYPE, DoorType.fromString(type, DoorType.WAFFLE)),
           Block.UPDATE_ALL
         );
         worldIn.setBlock(
           pos.above(),
-          worldIn.getBlockState(pos.above()).setValue(TYPE, DoorType.valueOf(type.toUpperCase())),
+            worldIn.getBlockState(pos.above()).setValue(TYPE, DoorType.fromString(type, DoorType.WAFFLE)),
           Block.UPDATE_ALL
         );
 

--- a/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
+++ b/src/main/java/com/ldtteam/domumornamentum/block/vanilla/TrapdoorBlock.java
@@ -125,7 +125,7 @@ public class TrapdoorBlock extends AbstractBlockTrapdoor<TrapdoorBlock> implemen
     @Override
     public BlockState getStateForPlacement(final @NotNull BlockPlaceContext context)
     {
-        return super.getStateForPlacement(context).setValue(TYPE, TrapdoorType.valueOf(context.getItemInHand().getOrCreateTag().getString("type")));
+        return super.getStateForPlacement(context).setValue(TYPE, TrapdoorType.fromString(context.getItemInHand().getOrCreateTag().getString("type"), TrapdoorType.WAFFLE));
     }
 
     @Override

--- a/src/main/java/com/ldtteam/domumornamentum/client/event/handlers/ModBusEventHandler.java
+++ b/src/main/java/com/ldtteam/domumornamentum/client/event/handlers/ModBusEventHandler.java
@@ -33,15 +33,7 @@ public class ModBusEventHandler
           (itemStack, clientLevel, livingEntity, i) -> {
             if (!itemStack.getOrCreateTag().contains("type"))
                 return 0f;
-
-              TrapdoorType trapdoorType;
-              try {
-                  trapdoorType = TrapdoorType.valueOf(itemStack.getOrCreateTag().getString("type").toUpperCase());
-              } catch (Exception ex) {
-                  trapdoorType = TrapdoorType.FULL;
-              }
-
-              return trapdoorType.ordinal();
+              return TrapdoorType.fromString(itemStack.getOrCreateTag().getString("type"), TrapdoorType.WAFFLE).ordinal();
           }));
         event.enqueueWork(() -> ItemProperties.register(IModBlocks.getInstance().getDoor().asItem(), new ResourceLocation(Constants.DOOR_MODEL_OVERRIDE),
           (itemStack, clientLevel, livingEntity, i) -> handleDoorTypeOverride(itemStack)));
@@ -98,18 +90,7 @@ public class ModBusEventHandler
         {
             return 0f;
         }
-
-        DoorType doorType;
-        try
-        {
-            doorType = DoorType.valueOf(itemStack.getOrCreateTag().getString("type").toUpperCase());
-        }
-        catch (Exception ex)
-        {
-            doorType = DoorType.FULL;
-        }
-
-        return doorType.ordinal();
+        return DoorType.fromString(itemStack.getOrCreateTag().getString("type"), DoorType.WAFFLE).ordinal();
     }
 
     private static float handleFancyDoorTypeOverride(ItemStack itemStack)
@@ -119,17 +100,7 @@ public class ModBusEventHandler
             return 0f;
         }
 
-        FancyDoorType doorType;
-        try
-        {
-            doorType = FancyDoorType.valueOf(itemStack.getOrCreateTag().getString("type").toUpperCase());
-        }
-        catch (Exception ex)
-        {
-            doorType = FancyDoorType.FULL;
-        }
-
-        return doorType.ordinal();
+        return FancyDoorType.fromString(itemStack.getOrCreateTag().getString("type"), FancyDoorType.FULL).ordinal();
     }
 
     private static float handleFancyTrapdoorTypeOverride(ItemStack itemStack)
@@ -139,17 +110,7 @@ public class ModBusEventHandler
             return 0f;
         }
 
-        FancyTrapdoorType doorType;
-        try
-        {
-            doorType = FancyTrapdoorType.valueOf(itemStack.getOrCreateTag().getString("type").toUpperCase());
-        }
-        catch (Exception ex)
-        {
-            doorType = FancyTrapdoorType.FULL;
-        }
-
-        return doorType.ordinal();
+        return FancyTrapdoorType.fromString(itemStack.getOrCreateTag().getString("type"), FancyTrapdoorType.FULL).ordinal();
     }
 
     private static float handleStaticTrapdoorTypeOverride(ItemStack itemStack)
@@ -159,17 +120,7 @@ public class ModBusEventHandler
             return 0f;
         }
 
-        TrapdoorType doorType;
-        try
-        {
-            doorType = TrapdoorType.valueOf(itemStack.getOrCreateTag().getString("type").toUpperCase());
-        }
-        catch (Exception ex)
-        {
-            doorType = TrapdoorType.FULL;
-        }
-
-        return doorType.ordinal();
+        return TrapdoorType.fromString(itemStack.getOrCreateTag().getString("type"), TrapdoorType.WAFFLE).ordinal();
     }
     private static float handlePostTypeOverride(ItemStack itemStack)
     {
@@ -178,16 +129,6 @@ public class ModBusEventHandler
             return 0f;
         }
 
-        PostType postType;
-        try
-        {
-            postType = PostType.valueOf(itemStack.getOrCreateTag().getString("type").toUpperCase());
-        }
-        catch (Exception ex)
-        {
-            postType = PostType.PLAIN;
-        }
-
-        return postType.ordinal();
+        return PostType.fromString(itemStack.getOrCreateTag().getString("type"), PostType.PLAIN).ordinal();
     }
 }

--- a/src/main/java/com/ldtteam/domumornamentum/item/decoration/FancyDoorBlockItem.java
+++ b/src/main/java/com/ldtteam/domumornamentum/item/decoration/FancyDoorBlockItem.java
@@ -52,23 +52,7 @@ public class FancyDoorBlockItem extends DoubleHighBlockItem implements IDoItem
     {
         super.appendHoverText(stack, worldIn, tooltip, flagIn);
 
-        FancyDoorType doorType;
-        try
-        {
-            if (stack.getOrCreateTag().contains("type"))
-            {
-                doorType = FancyDoorType.valueOf(stack.getOrCreateTag().getString("type").toUpperCase());
-            }
-            else
-            {
-                doorType = FancyDoorType.FULL;
-            }
-        }
-        catch (Exception ex)
-        {
-            doorType = FancyDoorType.FULL;
-        }
-
+        FancyDoorType doorType = FancyDoorType.fromString(stack.getOrCreateTag().getString("type"), FancyDoorType.FULL);
         tooltip.add(Component.translatable(Constants.MOD_ID + ".origin.tooltip"));
         tooltip.add(Component.literal(""));
         tooltip.add(Component.translatable(

--- a/src/main/java/com/ldtteam/domumornamentum/item/decoration/FancyTrapdoorBlockItem.java
+++ b/src/main/java/com/ldtteam/domumornamentum/item/decoration/FancyTrapdoorBlockItem.java
@@ -50,16 +50,7 @@ public class FancyTrapdoorBlockItem extends BlockItem implements IDoItem
     {
         super.appendHoverText(stack, worldIn, tooltip, flagIn);
 
-        FancyTrapdoorType trapdoorType;
-        try {
-            if (stack.getOrCreateTag().contains("type"))
-                trapdoorType = FancyTrapdoorType.valueOf(stack.getOrCreateTag().getString("type").toUpperCase());
-            else
-                trapdoorType = FancyTrapdoorType.FULL;
-        } catch (Exception ex) {
-            trapdoorType = FancyTrapdoorType.FULL;
-        }
-
+        FancyTrapdoorType trapdoorType = FancyTrapdoorType.fromString(stack.getOrCreateTag().getString("type"), FancyTrapdoorType.FULL);
         tooltip.add(Component.translatable(Constants.MOD_ID + ".origin.tooltip"));
         tooltip.add(Component.literal(""));
         tooltip.add(Component.translatable(

--- a/src/main/java/com/ldtteam/domumornamentum/item/decoration/PanelBlockItem.java
+++ b/src/main/java/com/ldtteam/domumornamentum/item/decoration/PanelBlockItem.java
@@ -49,23 +49,7 @@ public class PanelBlockItem extends BlockItem implements IDoItem
     {
         super.appendHoverText(stack, worldIn, tooltip, flagIn);
 
-        TrapdoorType trapdoorType;
-        try
-        {
-            if (stack.getOrCreateTag().contains("type"))
-            {
-                trapdoorType = TrapdoorType.valueOf(stack.getOrCreateTag().getString("type").toUpperCase());
-            }
-            else
-            {
-                trapdoorType = TrapdoorType.FULL;
-            }
-        }
-        catch (Exception ex)
-        {
-            trapdoorType = TrapdoorType.FULL;
-        }
-
+        final TrapdoorType trapdoorType = TrapdoorType.fromString(stack.getOrCreateTag().getString("type"), TrapdoorType.FULL);
         tooltip.add(Component.translatable(Constants.MOD_ID + ".origin.tooltip"));
         tooltip.add(Component.literal(""));
         tooltip.add(Component.translatable(

--- a/src/main/java/com/ldtteam/domumornamentum/item/decoration/PostBlockItem.java
+++ b/src/main/java/com/ldtteam/domumornamentum/item/decoration/PostBlockItem.java
@@ -49,23 +49,7 @@ public class PostBlockItem extends BlockItem implements IDoItem
     {
         super.appendHoverText(stack, worldIn, tooltip, flagIn);
 
-        PostType postType;
-        try
-        {
-            if (stack.getOrCreateTag().contains("type"))
-            {
-                postType = PostType.valueOf(stack.getOrCreateTag().getString("type").toUpperCase());
-            }
-            else
-            {
-                postType = PostType.PLAIN;
-            }
-        }
-        catch (Exception ex)
-        {
-            postType = PostType.PLAIN;
-        }
-
+        PostType postType = PostType.fromString(stack.getOrCreateTag().getString("type"), PostType.PLAIN);
         tooltip.add(Component.translatable(Constants.MOD_ID + ".origin.tooltip"));
         tooltip.add(Component.literal(""));
         tooltip.add(Component.translatable(

--- a/src/main/java/com/ldtteam/domumornamentum/item/vanilla/DoorBlockItem.java
+++ b/src/main/java/com/ldtteam/domumornamentum/item/vanilla/DoorBlockItem.java
@@ -51,23 +51,7 @@ public class DoorBlockItem extends DoubleHighBlockItem implements IDoItem
     {
         super.appendHoverText(stack, worldIn, tooltip, flagIn);
 
-        DoorType doorType;
-        try
-        {
-            if (stack.getOrCreateTag().contains("type"))
-            {
-                doorType = DoorType.valueOf(stack.getOrCreateTag().getString("type").toUpperCase());
-            }
-            else
-            {
-                doorType = DoorType.FULL;
-            }
-        }
-        catch (Exception ex)
-        {
-            doorType = DoorType.FULL;
-        }
-
+        DoorType doorType = DoorType.fromString(stack.getOrCreateTag().getString("type"), DoorType.WAFFLE);
         tooltip.add(Component.translatable(Constants.MOD_ID + ".origin.tooltip"));
         tooltip.add(Component.literal(""));
         tooltip.add(Component.translatable(

--- a/src/main/java/com/ldtteam/domumornamentum/item/vanilla/TrapdoorBlockItem.java
+++ b/src/main/java/com/ldtteam/domumornamentum/item/vanilla/TrapdoorBlockItem.java
@@ -49,23 +49,7 @@ public class TrapdoorBlockItem extends BlockItem implements IDoItem
     {
         super.appendHoverText(stack, worldIn, tooltip, flagIn);
 
-        TrapdoorType trapdoorType;
-        try
-        {
-            if (stack.getOrCreateTag().contains("type"))
-            {
-                trapdoorType = TrapdoorType.valueOf(stack.getOrCreateTag().getString("type").toUpperCase());
-            }
-            else
-            {
-                trapdoorType = TrapdoorType.FULL;
-            }
-        }
-        catch (Exception ex)
-        {
-            trapdoorType = TrapdoorType.FULL;
-        }
-
+        final TrapdoorType trapdoorType = TrapdoorType.fromString(stack.getOrCreateTag().getString("type"), TrapdoorType.WAFFLE);
         tooltip.add(Component.translatable(Constants.MOD_ID + ".origin.tooltip"));
         tooltip.add(Component.literal(""));
         tooltip.add(Component.translatable(

--- a/src/main/java/com/ldtteam/domumornamentum/util/EnumHelper.java
+++ b/src/main/java/com/ldtteam/domumornamentum/util/EnumHelper.java
@@ -1,0 +1,41 @@
+package com.ldtteam.domumornamentum.util;
+
+import net.minecraft.util.StringRepresentable;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Helper class for safely retrieving values from an enum, combines enum name + serialized name
+ */
+public final class EnumHelper
+{
+    private EnumHelper() {}
+
+    public static <E extends Enum<E> & StringRepresentable> Map<String, E> createMap(Class<E> enumClass)
+    {
+        Map<String, E> map = new HashMap<>();
+
+        for (E value : enumClass.getEnumConstants())
+        {
+            map.put(value.name().toLowerCase(Locale.ROOT), value);
+            map.put(value.getSerializedName().toLowerCase(Locale.ROOT), value);
+        }
+
+        return map;
+    }
+
+    public static <E extends Enum<E>> E fromString(
+        Map<String, E> idMap,
+        String input,
+        E defaultValue)
+    {
+        if (input == null)
+        {
+            return defaultValue;
+        }
+
+        return idMap.getOrDefault(input.toLowerCase(Locale.ROOT), defaultValue);
+    }
+}


### PR DESCRIPTION
Closes #330

- Fixes crashes related to retrieving enum types from saved string ids
- Introduced new method fromString(string, defaultValue) to all enums to safely retrieve a value or the given default
- Removed previous copy pasted try cache blocks to deal with these crashes/missing values