### PR TITLE
Provide block state when querying sub-model quads in `RetexturedBakedModelBuilder`

### DIFF
--- a/src/main/java/com/ldtteam/domumornamentum/client/model/baked/RetexturedBakedModelBuilder.java
+++ b/src/main/java/com/ldtteam/domumornamentum/client/model/baked/RetexturedBakedModelBuilder.java
@@ -163,7 +163,7 @@ public class RetexturedBakedModelBuilder {
 
         final ReplacementModelData modelData = this.retexturingMaps.get(source.getSprite().contents().name());
         List<BakedQuad> targetQuads = modelData.model().getQuads(
-                null,
+                modelData.state(),
                 direction,
                 RANDOM,
                 ModelData.EMPTY,
@@ -174,7 +174,7 @@ public class RetexturedBakedModelBuilder {
         //Lets try with the targeting direction (the normal) of the quad itself.
         if (targetQuads.isEmpty())
             targetQuads = modelData.model().getQuads(
-                    null,
+                    modelData.state(),
                     source.getDirection(),
                     RANDOM,
                     ModelData.EMPTY,


### PR DESCRIPTION
# Checklist
- [x] I have read and accept the Contributing Guidelines
- [x] I have tested and confirmed my changes are working on the most recent commit of this pull request
<!--
When using AI we require you to confirm the points in this readme.
Please state in which parts of the code AI was used.
-->
- [ ] I have used AI in the creation of this pull request

# Related issues
Closes #345

# Changes proposed in this pull request
This PR passes the block state from `ReplacementModelData` to the sub-model when requesting quads in `RetexturedBakedModelBuilder#getRetexturingQuad`.

With this PR, the example in the linked issue looks correct:
<img width="289" height="299" alt="image" src="https://github.com/user-attachments/assets/636f3a6e-ee25-4e8a-8e19-c98bc17da6ca" />
